### PR TITLE
Fix #16: C interface and fix pointer in progeo

### DIFF
--- a/src/stable/libs/progeo/progeo.c
+++ b/src/stable/libs/progeo/progeo.c
@@ -533,7 +533,7 @@ void reverse_update_camera_matrix(TPinHoleCamera *camera)
 	in.y = 0;
 	in.h = 0;
 
-	backproject(&out, in, camera);
+	backproject(&out, in, *camera);
 
 	camera->foa.X = out.X;
 	camera->foa.Y = out.Y;
@@ -558,7 +558,7 @@ void reverse_update_camera_matrix(TPinHoleCamera *camera)
 	p2_rt_complete.y = 1;
 	p2_rt_complete.h = 0;
 
-	backproject(&p3, p2_rt_complete, camera);
+	backproject(&p3, p2_rt_complete, *camera);
 
 	TPinHoleCamera cameraAux; 
 	cameraAux = *camera;

--- a/src/stable/libs/progeo/progeo.h
+++ b/src/stable/libs/progeo/progeo.h
@@ -95,6 +95,16 @@ extern "C" {
 	int displayline(HPoint2D p1, HPoint2D p2, HPoint2D *a, HPoint2D *b, TPinHoleCamera camera);
 	void display_camerainfo(TPinHoleCamera camera);
 }
+#else
+TPinHoleCamera xmlReader(TPinHoleCamera* camera, const char *filename);
+void xmlWriter(TPinHoleCamera camera, const char *filename);
+void update_camera_matrix(TPinHoleCamera *camera);
+void reverse_update_camera_matrix(TPinHoleCamera *camera);
+void update_stereocamera_matrix(TPinHoleStereocamera *stereo);
+int project(HPoint3D in, HPoint2D *out, TPinHoleCamera camera);
+int backproject(HPoint3D *out, HPoint2D in, TPinHoleCamera camera);
+int displayline(HPoint2D p1, HPoint2D p2, HPoint2D *a, HPoint2D *b, TPinHoleCamera camera);
+void display_camerainfo(TPinHoleCamera camera);
 #endif
 
 #endif /*PROGEO_H*/


### PR DESCRIPTION
Details here: https://github.com/RoboticsURJC/JdeRobot/issues/16

This will solve a warning while compiling progeo library and a possible bug using pointers. Maybe in C++ it will work, we don't need to test it because progeo.c code is pure C, not C++ but it's possible that components using progeo needs `extern "C"` clause if they are programmed in C++.