### PR TITLE
Appends readme with newer package name of libogre-dev for Ubuntu 14.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ JdeRobot is a project developed by Robotics Group of Universidad Rey Juan Carlos
 $ sudo aptitude install build-essential libtinyxml-dev libtbb-dev libxml2-dev libqt4-dev pkg-config libprotoc-dev libfreeimage-dev libprotobuf-dev protobuf-compiler libboost-all-dev freeglut3-dev cmake libogre-dev libtar-dev libcurl4-openssl-dev libcegui-mk2-dev libswscale-dev libavformat-dev libavcodec-dev 
 ```
 
+For Ubuntu 14.04, `libogre-dev` is not present, so to install Ogre 1.9 you need to install `libogre-1.9-dev` .
 For other dependencies, like the `GTK` stuff, refer to the [Installation Manual](http://jderobot.org/Manual-5#Installing_JdeRobot_5). You may want to install the missing dependencies according to your `cmake` output.
 
 # Download source code


### PR DESCRIPTION
As per the information at website of Ogre3d, Ubuntu 14.04 and above need to use ` libogre-1.9-dev` as the package name for installation. 
http://www.ogre3d.org/tikiwiki/Installing+the+Ogre+SDK?tikiversion=Linux

Opening this pull request from Master branch itself since the change is small and unbreaking, Ubuntu being the most used distro.

#GSoC15