### PR TITLE
Refactoring of introrob. Replaced IplImage to cv::Mat

### DIFF
--- a/src/stable/components/introrob/API.cpp
+++ b/src/stable/components/introrob/API.cpp
@@ -57,20 +57,16 @@ namespace introrob {
         return this->encodersData;
     }
 
-    IplImage* Api::getImageCamera1() {
-        IplImage src = *this->image1;
-        IplImage* cvResultado = cvCreateImage(cvGetSize(&src), IPL_DEPTH_8U, 3);
-        cvCopy(&src, cvResultado);
+    cv::Mat Api::getImageCamera1() {
 
-        return cvResultado;
+	cv::Mat cvResultado = this->image1.clone();
+	return cvResultado;
     }
 
-    IplImage* Api::getImageCamera2() {
-        IplImage src = *this->image2;
-        IplImage* cvResultado = cvCreateImage(cvGetSize(&src), IPL_DEPTH_8U, 3);
-        cvCopy(&src, cvResultado);
+    cv::Mat Api::getImageCamera2() {
 
-        return cvResultado;
+	cv::Mat cvResultado = this->image2.clone();
+	return cvResultado;
     }
 
     void Api::setMotorV(float motorV) {
@@ -128,15 +124,13 @@ namespace introrob {
 
     void Api::imageCameras2openCV() {
         pthread_mutex_lock(&this->controlGui);
-        cvReleaseImage(&imageCameraRight);
-        this->imageCameraRight = cvCreateImage(cvSize(imageData2->description->width, imageData2->description->height), 8, 3);
 
-        memcpy((unsigned char *) imageCameraRight->imageData, &(imageData2->pixelData[0]), imageCameraRight->width * imageCameraRight->height * 3);
+	// cv::Mat processing
+	this->imageCameraRight.create(imageData2->description->height, imageData2->description->width, CV_8UC3);
+	memcpy((unsigned char *) this->imageCameraRight.data, &(imageData2->pixelData[0]), this->imageCameraRight.cols*imageCameraRight.rows*3);
 
-        cvReleaseImage(&imageCameraLeft);
-        this->imageCameraLeft = cvCreateImage(cvSize(imageData1->description->width, imageData1->description->height), 8, 3);
-
-        memcpy((unsigned char *) imageCameraLeft->imageData, &(imageData1->pixelData[0]), imageCameraLeft->width * imageCameraLeft->height * 3);
+	this->imageCameraLeft.create(imageData1->description->height, imageData1->description->width, CV_8UC3);
+	memcpy((unsigned char *) this->imageCameraLeft.data, &(imageData1->pixelData[0]), this->imageCameraLeft.cols*imageCameraLeft.rows*3);
 
         /*
         colorspaces::Image::FormatPtr fmt1 = colorspaces::Image::Format::searchFormat(imageData1->description->format);
@@ -273,22 +267,7 @@ namespace introrob {
     void Api::showMyImage() {
         int i, j;
 
-        //IplImage src = *this->imageCameraLeft;
-/*
-        IplImage* cvResultado = cvCreateImage(cvGetSize(&src), IPL_DEPTH_8U, 3);
-        cvCopy(&src, cvResultado);
-        for (i = 0; i < cvResultado->width; i++) {
-            for (j = 0; j < cvResultado->height; j++) {
-                cvResultado->imageData[j * cvResultado->widthStep + i * cvResultado->nChannels] = this->imageCameraLeft->imageData[j * this->imageCameraLeft->widthStep + i * this->imageCameraLeft->nChannels + 2]; //R
-                cvResultado->imageData[j * cvResultado->widthStep + i * cvResultado->nChannels + 1] = this->imageCameraLeft->imageData[j * this->imageCameraLeft->widthStep + i * this->imageCameraLeft->nChannels + 1]; //R
-                cvResultado->imageData[j * cvResultado->widthStep + i * cvResultado->nChannels + 2] = this->imageCameraLeft->imageData[j * this->imageCameraLeft->widthStep + i * this->imageCameraLeft->nChannels]; //R
-            }
-        }
-*/
-
-        cvShowImage("DebuggingWin", this->imageCameraLeft);
-
-
+        imshow("DebuggingWin", this->imageCameraLeft);
 
     }
 

--- a/src/stable/components/introrob/API.h
+++ b/src/stable/components/introrob/API.h
@@ -72,8 +72,8 @@ namespace introrob {
         int getNumLasers();
         jderobot::IntSeq getDistancesLaser();
         jderobot::EncodersDataPtr getEncodersData();
-        IplImage* getImageCamera1();
-        IplImage* getImageCamera2();
+        cv::Mat getImageCamera1();
+        cv::Mat getImageCamera2();
 
         //SETS
         void setMotorV(float motorV);
@@ -104,8 +104,8 @@ namespace introrob {
         jderobot::Pose3DEncodersDataPtr Pose3Dencoders2;
         jderobot::Pose3DMotorsData* Pose3DmotorsData1;
         jderobot::Pose3DMotorsData* Pose3DmotorsData2;
-        colorspaces::Image* image1; // Image camera1 processed to manipulate with openCV
-        colorspaces::Image* image2; // Image camera2 processed to manipulate with openCV
+        cv::Mat image1; // Image camera1 processed to manipulate with openCV
+        cv::Mat image2; // Image camera2 processed to manipulate with openCV
         bool guiVisible;
         bool iterationControlActivated;
         //Variables used in NavigationAlgorithm
@@ -116,20 +116,20 @@ namespace introrob {
         bool segmentoPintado;
         int numlines;
         float extra_lines[MAX_LINES][9];
-        IplImage* imageOnCamera;
+        cv::Mat imageOnCamera;
         bool showImage;
         gint x_click_cameraleft, y_click_cameraleft, x_click_cameraright, y_click_cameraright;
         TPinHoleCamera myCamA, myCamB;
         Glib::RefPtr<Gdk::Pixbuf> imgBuff2, imgBuff;
         bool imagesReady;
         bool guiReady;
-        IplImage* imageCameraLeft;
-        IplImage* imageCameraRight;
+        cv::Mat imageCameraLeft;
+        cv::Mat imageCameraRight;
 
     private:
         //Variables used in NavigationAlgorithm
-        IplImage* imageCamera1;
-        IplImage* imageCamera2;
+        cv::Mat imageCamera1;
+        cv::Mat imageCamera2;
 
         struct XYZ {
             double x;

--- a/src/stable/components/introrob/API.h
+++ b/src/stable/components/introrob/API.h
@@ -27,8 +27,8 @@
 
 //#include "camera.h"
 #include <progeo/progeo.h>
-#include <cv.h>
-#include <highgui.h>
+#include <opencv2/core/core.hpp>
+#include <opencv2/highgui/highgui.hpp>
 #include <iostream>
 #include <Ice/Ice.h>
 #include <IceUtil/IceUtil.h>

--- a/src/stable/components/introrob/MyAlgorithms.cpp
+++ b/src/stable/components/introrob/MyAlgorithms.cpp
@@ -157,20 +157,8 @@ namespace introrob {
         /*En el siguiente ejemplo se filtra el color rojo de la cámara izquierda para repintar esos píxeles a negro. Para visualizar el resultado
         debemos desplegar la ventana "WINDOW DEBUGGING" y pulsar PLAY para hacer correr nuestro código*/
         imageCameras2openCV(); //Esta función es necesario llamarla ANTES de trabajar con las imágenes de las cámaras.
-        IplImage src = *this->imageCameraLeft; //Imagen de la cámara izquierda
 
-        for (i = 0; i < src.width; i++) {
-            for (j = 0; j < src.height; j++) {
-                if (((int) (unsigned char) src.imageData[(j * src.width + i) * src.nChannels] > 120) &&
-                        ((int) (unsigned char) src.imageData[(j * src.width + i) * src.nChannels + 1] < 70) &&
-                        ((int) (unsigned char) src.imageData[(j * src.width + i) * src.nChannels + 2] < 70)) {
-                    cont++;
-                    src.imageData[(j * src.width + i) * src.nChannels] = 255; //R
-                    src.imageData[(j * src.width + i) * src.nChannels + 1] = 255; //G
-                    src.imageData[(j * src.width + i) * src.nChannels + 2] = 0; //B
-                }
-            }
-        }
+        cv::line(imageCameraLeft, cv::Point2d(0,0), cv::Point2d(imageCameraLeft.cols, imageCameraLeft.rows), cv::Scalar::all(255), 3);
 
         /* A continuacion se muestran las coordenadas de los puntos obtenidos tras hacer click en alguna de las camaras */
         //std::cout << x_click_cameraleft << std::endl; // Coordenada x del punto donde se ha hecho click en la camara izquierda

--- a/src/stable/components/introrob/control.cpp
+++ b/src/stable/components/introrob/control.cpp
@@ -59,10 +59,9 @@ namespace introrob {
     }
 
     void Control::createImage(Api *api) {
-        cvReleaseImage(&image);
-        this->image = cvCreateImage(cvSize(api->imageData1->description->width, api->imageData1->description->height), 8, 3);
 
-        memcpy((unsigned char *) image->imageData, &(api->imageData1->pixelData[0]), image->width * image->height * 3);
+        this->image.create(api->imageData1->description->height, api->imageData1->description->width, CV_8UC3);
+	memcpy((unsigned char *) this->image.data, &(api->imageData1->pixelData[0]), this->image.cols*image.rows*3);
 /*
         colorspaces::Image::FormatPtr fmt = colorspaces::Image::Format::searchFormat(api->imageData1->description->format);
 
@@ -70,35 +69,34 @@ namespace introrob {
             throw "Format not supported";
 */
         api->imgBuff =
-                Gdk::Pixbuf::create_from_data((const guint8*) this->image->imageData,
+                Gdk::Pixbuf::create_from_data((const guint8*) this->image.data,
                 Gdk::COLORSPACE_RGB,
                 false,
-                this->image->depth,
-                this->image->width,
-                this->image->height,
-                this->image->widthStep);
+                8, //this->image.depth,
+                this->image.cols,
+                this->image.rows,
+                this->image.step);
 
     }
 
     void Control::createImage2(Api *api) {
-        cvReleaseImage(&image2);
-        this->image2 = cvCreateImage(cvSize(api->imageData2->description->width, api->imageData2->description->height), 8, 3);
 
-        memcpy((unsigned char *) image2->imageData, &(api->imageData2->pixelData[0]), image2->width * image2->height * 3);
+        this->image2.create(api->imageData2->description->height, api->imageData2->description->width, CV_8UC3);
+	memcpy((unsigned char *) this->image2.data, &(api->imageData2->pixelData[0]), this->image2.cols*image2.rows*3);
 /*
         colorspaces::Image::FormatPtr fmt2 = colorspaces::Image::Format::searchFormat(api->imageData2->description->format);
 
         if (!fmt2)
             throw "Format not supported";
 */
-        api->imgBuff2 =
-                Gdk::Pixbuf::create_from_data((const guint8*) this->image2->imageData,
+         api->imgBuff2 =
+                Gdk::Pixbuf::create_from_data((const guint8*) this->image2.data,
                 Gdk::COLORSPACE_RGB,
                 false,
-                this->image2->depth,
-                this->image2->width,
-                this->image2->height,
-                this->image2->widthStep);
+                8, //this->image2.depth,
+                this->image2.cols,
+                this->image2.rows,
+                this->image2.step);
     }
 
     // Send the actuators info to Gazebo with ICE

--- a/src/stable/components/introrob/control.h
+++ b/src/stable/components/introrob/control.h
@@ -68,8 +68,8 @@ namespace introrob {
         void createImage(Api *api);
         void createImage2(Api *api);
 
-        IplImage* image;
-        IplImage* image2;
+        cv::Mat image;
+        cv::Mat image2;
 
 
     }; //class

--- a/src/stable/components/introrob/drawarea.h
+++ b/src/stable/components/introrob/drawarea.h
@@ -27,7 +27,6 @@
 
 #include <string>
 #include <iostream>
-#include <cv.h>
 #include <pthread.h>
 #include <gtkmm.h>
 #include <gtkglmm.h>

--- a/src/stable/components/introrob/gui.h
+++ b/src/stable/components/introrob/gui.h
@@ -23,7 +23,6 @@
 #define INTROROB_GUI_H
 
 #include <math.h>
-#include <cv.h>
 #include <GL/gl.h>
 #include <GL/glu.h>
 #include <GL/glut.h>

--- a/src/stable/components/introrob/gui.h
+++ b/src/stable/components/introrob/gui.h
@@ -72,7 +72,7 @@ namespace introrob {
         void updateCameras(Api *api);
         void resetAPI(Api *api);
         void setDestino();
-        void prepare2draw(IplImage &image);
+        void prepare2draw(cv::Mat image);
         void calculate_projection_line(HPoint2D pix, int idcamera);
         void get3DPositionZ(TPinHoleCamera * camera, HPoint3D &res, HPoint2D in, float Z);
         void add_line(float x0, float y0, float z0, float x1, float y1, float z1, int color);

--- a/src/stable/components/introrob/introrob.cfg
+++ b/src/stable/components/introrob/introrob.cfg
@@ -1,6 +1,6 @@
 introrob.Motors.Proxy=Motors:tcp -h localhost -p 9999
-introrob.Camera1.Proxy=cam_sensor_left:tcp -h localhost -p 9995
-introrob.Camera2.Proxy=cam_sensor_right:tcp -h localhost -p 9994
+introrob.Camera1.Proxy=cam_sensor_left:tcp -h localhost -p 9994
+introrob.Camera2.Proxy=cam_sensor_right:tcp -h localhost -p 9995
 introrob.Encoders.Proxy=Encoders:tcp -h localhost -p 9997
 introrob.Laser.Proxy=Laser:tcp -h localhost -p 9996
 introrob.Pose3Dencoders2.Proxy=Pose3DEncoders2:tcp -h localhost -p 9992


### PR DESCRIPTION
Replacement of the data type of the images handled by introrob. Removed the old type IplImage to the new and more efficient type cv::Mat