### PR TITLE
Updated pioneer plugins and refactorization of introrob

### DIFF
--- a/Deps/gazebo/CMakeLists.txt
+++ b/Deps/gazebo/CMakeLists.txt
@@ -1,4 +1,4 @@
-PKG_CHECK_MODULES(GAZEBO QUIET gazebo<=5.0.1 )
+PKG_CHECK_MODULES(GAZEBO QUIET gazebo<=5.1.0 )
 #include_directories(${GAZEBO_INCLUDE_DIRS})
 link_directories(${GAZEBO_LIBRARY_DIRS})
 

--- a/src/stable/components/gazeboserver/plugins/pioneer/CMakeLists.txt
+++ b/src/stable/components/gazeboserver/plugins/pioneer/CMakeLists.txt
@@ -32,10 +32,11 @@ target_link_libraries(laser
 
 add_library(camera_dump SHARED camera_dump.cc)
 target_link_libraries(camera_dump ${GAZEBO_libraries} 
-	CameraPlugin 	
-	${GAZEBO_libraries} 
+	CameraPlugin 
+	colorspacesmmshare	
 	${ZeroCIce_LIBRARIES}     
     JderobotInterfaces)
+    
     
 add_library(pose3dencoders SHARED pose3dencoders.cc)
 target_link_libraries(pose3dencoders ${GAZEBO_libraries} 	 	

--- a/src/stable/components/gazeboserver/plugins/pioneer/camera_dump.cc
+++ b/src/stable/components/gazeboserver/plugins/pioneer/camera_dump.cc
@@ -48,11 +48,12 @@ namespace gazebo
 		if(count==0){
 			std::vector<std::string> tokens;
 			nameCamera = this->parentSensor->GetCamera()->GetName();
-  			boost::split(tokens, nameCamera, boost::is_any_of("::"));
-  			boost::split(tokens, tokens[2], boost::is_any_of("("));
-			nameGlobal = tokens[0];
+			nameGlobal = nameCamera;
+  			//boost::split(tokens, nameCamera, boost::is_any_of("::"));
+  			//boost::split(tokens, tokens[2], boost::is_any_of("("));
+			//nameGlobal = tokens[0];
 			// El nombre del fichero de configuracion tiene que coincidir con el de la cámara en el .world y el .cfg 
-			nameCamera = std::string("--Ice.Config=" + tokens[0] + ".cfg"); 
+			nameCamera = std::string("--Ice.Config=" + nameCamera + ".cfg"); 
 			
 			if (count == 0){
 				pthread_t thr_gui;
@@ -92,6 +93,8 @@ class CameraI: virtual public jderobot::Camera {
 			std::cout << "Constructor CameraI" << std::endl;
 
 			imageDescription = (new jderobot::ImageDescription());
+			cameraDescription = (new jderobot::CameraDescription());
+			cameraDescription->name = "camera Introrob";
 
         	replyTask = new ReplyTask(this);
 		    replyTask->start(); // my own thread

--- a/src/stable/components/gazeboserver/plugins/pioneer/motors.cc
+++ b/src/stable/components/gazeboserver/plugins/pioneer/motors.cc
@@ -1,3 +1,4 @@
+
 #include "motors.h"
 
 enum {
@@ -38,22 +39,22 @@ namespace gazebo {
             gzerr << "DiffDrive plugin missing <right_joint> element\n";
 
         this->leftJoint = _model->GetJoint(
-                _sdf->GetElement("left_joint")->GetValueString());
+                _sdf->GetElement("left_joint")->Get<std::string>());
         this->rightJoint = _model->GetJoint(
-                _sdf->GetElement("right_joint")->GetValueString());
+                _sdf->GetElement("right_joint")->Get<std::string>());
 
         if (_sdf->HasElement("torque"))
-            this->torque = _sdf->GetElement("torque")->GetValueDouble();
+            this->torque = _sdf->GetElement("torque")->Get<double>();
         else {
             gzwarn << "No torque value set for the DiffDrive plugin.\n";
             this->torque = 5.0;
         }
         if (!this->leftJoint)
             gzerr << "Unable to find left joint["
-                << _sdf->GetElement("left_joint")->GetValueString() << "]\n";
+                << _sdf->GetElement("left_joint")->Get<std::string>() << "]\n";
         if (!this->rightJoint)
             gzerr << "Unable to find right joint["
-                << _sdf->GetElement("right_joint")->GetValueString() << "]\n";
+                << _sdf->GetElement("right_joint")->Get<std::string>() << "]\n";
 
 
 
@@ -132,8 +133,8 @@ namespace gazebo {
         this->leftJoint->SetVelocity(0, leftVelDesired);
         this->rightJoint->SetVelocity(0, rightVelDesired);
 
-        this->leftJoint->SetMaxForce(0, this->torque);
-        this->rightJoint->SetMaxForce(0, this->torque);
+        this->leftJoint->SetParam("fmax", 0, this->torque);
+        this->rightJoint->SetParam("fmax", 0, this->torque);
     }
 
     class MotorsI : virtual public jderobot::Motors {

--- a/src/stable/components/gazeboserver/plugins/pioneer/motors.cc
+++ b/src/stable/components/gazeboserver/plugins/pioneer/motors.cc
@@ -130,8 +130,8 @@ namespace gazebo {
 		std::cout << "rightVelDesired " << rightVelDesired << std::endl;
 		std::cout << "torque " << torque << std::endl;
 */
-        this->leftJoint->SetVelocity(0, leftVelDesired);
-        this->rightJoint->SetVelocity(0, rightVelDesired);
+        this->leftJoint->SetParam("vel", 0, leftVelDesired);
+        this->rightJoint->SetParam("vel", 0, rightVelDesired);
 
         this->leftJoint->SetParam("fmax", 0, this->torque);
         this->rightJoint->SetParam("fmax", 0, this->torque);

--- a/src/stable/components/gazeboserver/plugins/pioneer/pose3dencoders.cc
+++ b/src/stable/components/gazeboserver/plugins/pioneer/pose3dencoders.cc
@@ -31,10 +31,10 @@ namespace gazebo {
 
         if (!this->cameraLeft.joint_pose3dencoders_pan)
             gzerr << "Unable to find left joint pose3dencoders_pan["
-                << _sdf->GetElement("left_joint_pose3dencoders_pan")->GetValueString() << "]\n";
+                << _sdf->GetElement("left_joint_pose3dencoders_pan")->Get<std::string>() << "]\n";
         if (!this->cameraLeft.joint_pose3dencoders_tilt)
             gzerr << "Unable to find left joint pose3dencoders_tilt["
-                << _sdf->GetElement("left_joint_pose3dencoders_tilt")->GetValueString() << "]\n";
+                << _sdf->GetElement("left_joint_pose3dencoders_tilt")->Get<std::string>() << "]\n";
         this->cameraLeft.camera_link_pan = this->model->GetLink("camera_column_body_left");
         this->cameraLeft.camera_link_tilt = this->model->GetLink("camera_top_body_left");
 
@@ -51,17 +51,17 @@ namespace gazebo {
 
         if (!this->cameraRight.joint_pose3dencoders_pan)
             gzerr << "Unable to find right joint pose3dencoders_pan["
-                << _sdf->GetElement("right_joint_pose3dencoders_pan")->GetValueString() << "]\n";
+                << _sdf->GetElement("right_joint_pose3dencoders_pan")->Get<std::string>() << "]\n";
         if (!this->cameraRight.joint_pose3dencoders_tilt)
             gzerr << "Unable to find right joint pose3dencoders_tilt["
-                << _sdf->GetElement("right_joint_pose3dencoders_tilt")->GetValueString() << "]\n";
+                << _sdf->GetElement("right_joint_pose3dencoders_tilt")->Get<std::string>() << "]\n";
         this->cameraRight.camera_link_pan = this->model->GetLink("camera_column_body_right");
         this->cameraRight.camera_link_tilt = this->model->GetLink("camera_top_body_right");
 
 
         //LOAD TORQUE        
         if (_sdf->HasElement("torque"))
-            this->torque = _sdf->GetElement("torque")->GetValueDouble();
+            this->torque = _sdf->GetElement("torque")->Get<double>();
         else {
             gzwarn << "No torque value set for the DiffDrive plugin.\n";
             this->torque = 5.0;
@@ -132,79 +132,79 @@ namespace gazebo {
         
         if (this->cameraLeft.motor.pan >= 0) {
             if (this->cameraLeft.encoder.pan < this->cameraLeft.motor.pan) {
-                this->cameraLeft.joint_pose3dencoders_pan->SetVelocity(0, -0.1);
-                this->cameraLeft.joint_pose3dencoders_pan->SetMaxForce(0, this->torque);
+                this->cameraLeft.joint_pose3dencoders_pan->SetParam("vel", 0, -0.1);
+                this->cameraLeft.joint_pose3dencoders_pan->SetParam("fmax", 0, this->torque);
                 //std::cout << "AQUI" << std::endl;
             } else {
-                this->cameraLeft.joint_pose3dencoders_pan->SetVelocity(0, 0);
-                this->cameraLeft.joint_pose3dencoders_pan->SetMaxForce(0, this->torque);
+                this->cameraLeft.joint_pose3dencoders_pan->SetParam("vel", 0, 0);
+                this->cameraLeft.joint_pose3dencoders_pan->SetParam("fmax", 0, this->torque);
             }
         } else {
             if (this->cameraLeft.encoder.pan > this->cameraLeft.motor.pan) {
-                this->cameraLeft.joint_pose3dencoders_pan->SetVelocity(0, 0.1);
-                this->cameraLeft.joint_pose3dencoders_pan->SetMaxForce(0, this->torque);
+                this->cameraLeft.joint_pose3dencoders_pan->SetParam("vel", 0, 0.1);
+                this->cameraLeft.joint_pose3dencoders_pan->SetParam("fmax", 0, this->torque);
                 //std::cout << "AQUI" << std::endl;
             } else {
-                this->cameraLeft.joint_pose3dencoders_pan->SetVelocity(0, 0);
-                this->cameraLeft.joint_pose3dencoders_pan->SetMaxForce(0, this->torque);
+                this->cameraLeft.joint_pose3dencoders_pan->SetParam("vel", 0, 0);
+                this->cameraLeft.joint_pose3dencoders_pan->SetParam("fmax", 0, this->torque);
             }            
         }
         if (this->cameraRight.motor.pan >= 0) {
             if (this->cameraRight.encoder.pan < this->cameraRight.motor.pan) {
-                this->cameraRight.joint_pose3dencoders_pan->SetVelocity(0, -0.1);
-                this->cameraRight.joint_pose3dencoders_pan->SetMaxForce(0, this->torque);
+                this->cameraRight.joint_pose3dencoders_pan->SetParam("vel",0, -0.1);
+                this->cameraRight.joint_pose3dencoders_pan->SetParam("fmax",0, this->torque);
                 //std::cout << "AQUI" << std::endl;
             } else {
-                this->cameraRight.joint_pose3dencoders_pan->SetVelocity(0, 0);
-                this->cameraRight.joint_pose3dencoders_pan->SetMaxForce(0, this->torque);
+                this->cameraRight.joint_pose3dencoders_pan->SetParam("vel",0, 0);
+                this->cameraRight.joint_pose3dencoders_pan->SetParam("fmax",0, this->torque);
             }
         } else {
             if (this->cameraRight.encoder.pan > this->cameraRight.motor.pan) {
-                this->cameraRight.joint_pose3dencoders_pan->SetVelocity(0, 0.1);
-                this->cameraRight.joint_pose3dencoders_pan->SetMaxForce(0, this->torque);
+                this->cameraRight.joint_pose3dencoders_pan->SetParam("vel",0, 0.1);
+                this->cameraRight.joint_pose3dencoders_pan->SetParam("fmax",0, this->torque);
                 //std::cout << "AQUI" << std::endl;
             } else {
-                this->cameraRight.joint_pose3dencoders_pan->SetVelocity(0, 0);
-                this->cameraRight.joint_pose3dencoders_pan->SetMaxForce(0, this->torque);
+                this->cameraRight.joint_pose3dencoders_pan->SetParam("vel",0, 0);
+                this->cameraRight.joint_pose3dencoders_pan->SetParam("fmax",0, this->torque);
             }            
         }
 
         if (this->cameraLeft.motor.tilt >= 0) {
             if (this->cameraLeft.encoder.tilt < this->cameraLeft.motor.tilt) {
-                this->cameraLeft.joint_pose3dencoders_tilt->SetVelocity(0, -0.1);
-                this->cameraLeft.joint_pose3dencoders_tilt->SetMaxForce(0, this->torque);
+                this->cameraLeft.joint_pose3dencoders_tilt->SetParam("vel", 0, -0.1);
+                this->cameraLeft.joint_pose3dencoders_tilt->SetParam("fmax", 0, this->torque);
                 //std::cout << "AQUI" << std::endl;
             } else {
-                this->cameraLeft.joint_pose3dencoders_tilt->SetVelocity(0, 0);
-                this->cameraLeft.joint_pose3dencoders_tilt->SetMaxForce(0, this->torque);
+                this->cameraLeft.joint_pose3dencoders_tilt->SetParam("vel", 0, 0);
+                this->cameraLeft.joint_pose3dencoders_tilt->SetParam("fmax", 0, this->torque);
             }
         } else {
             if (this->cameraLeft.encoder.tilt > this->cameraLeft.motor.tilt) {
-                this->cameraLeft.joint_pose3dencoders_tilt->SetVelocity(0, 0.1);
-                this->cameraLeft.joint_pose3dencoders_tilt->SetMaxForce(0, this->torque);
+                this->cameraLeft.joint_pose3dencoders_tilt->SetParam("vel", 0, 0.1);
+                this->cameraLeft.joint_pose3dencoders_tilt->SetParam("fmax",0, this->torque);
                 //std::cout << "AQUI" << std::endl;
             } else {
-                this->cameraLeft.joint_pose3dencoders_tilt->SetVelocity(0, 0);
-                this->cameraLeft.joint_pose3dencoders_tilt->SetMaxForce(0, this->torque);
+                this->cameraLeft.joint_pose3dencoders_tilt->SetParam("vel", 0, 0);
+                this->cameraLeft.joint_pose3dencoders_tilt->SetParam("fmax",0, this->torque);
             }            
         }
         if (this->cameraRight.motor.tilt >= 0) {
             if (this->cameraRight.encoder.tilt < this->cameraRight.motor.tilt) {
-                this->cameraRight.joint_pose3dencoders_tilt->SetVelocity(0, -0.1);
-                this->cameraRight.joint_pose3dencoders_tilt->SetMaxForce(0, this->torque);
+                this->cameraRight.joint_pose3dencoders_tilt->SetParam("vel", 0, -0.1);
+                this->cameraRight.joint_pose3dencoders_tilt->SetParam("fmax",0, this->torque);
                 //std::cout << "AQUI" << std::endl;
             } else {
-                this->cameraRight.joint_pose3dencoders_tilt->SetVelocity(0, 0);
-                this->cameraRight.joint_pose3dencoders_tilt->SetMaxForce(0, this->torque);
+                this->cameraRight.joint_pose3dencoders_tilt->SetParam("vel", 0, 0);
+                this->cameraRight.joint_pose3dencoders_tilt->SetParam("fmax",0, this->torque);
             }
         } else {
             if (this->cameraRight.encoder.tilt > this->cameraRight.motor.tilt) {
-                this->cameraRight.joint_pose3dencoders_tilt->SetVelocity(0, 0.1);
-                this->cameraRight.joint_pose3dencoders_tilt->SetMaxForce(0, this->torque);
+                this->cameraRight.joint_pose3dencoders_tilt->SetParam("vel", 0, 0.1);
+                this->cameraRight.joint_pose3dencoders_tilt->SetParam("fmax",0, this->torque);
                 //std::cout << "AQUI" << std::endl;
             } else {
-                this->cameraRight.joint_pose3dencoders_tilt->SetVelocity(0, 0);
-                this->cameraRight.joint_pose3dencoders_tilt->SetMaxForce(0, this->torque);
+                this->cameraRight.joint_pose3dencoders_tilt->SetParam("vel", 0, 0);
+                this->cameraRight.joint_pose3dencoders_tilt->SetParam("fmax",0, this->torque);
             }            
         }        
         

--- a/src/stable/components/introrob/API.cpp
+++ b/src/stable/components/introrob/API.cpp
@@ -57,20 +57,16 @@ namespace introrob {
         return this->encodersData;
     }
 
-    IplImage* Api::getImageCamera1() {
-        IplImage src = *this->image1;
-        IplImage* cvResultado = cvCreateImage(cvGetSize(&src), IPL_DEPTH_8U, 3);
-        cvCopy(&src, cvResultado);
+    cv::Mat Api::getImageCamera1() {
 
-        return cvResultado;
+	cv::Mat cvResultado = this->image1.clone();
+	return cvResultado;
     }
 
-    IplImage* Api::getImageCamera2() {
-        IplImage src = *this->image2;
-        IplImage* cvResultado = cvCreateImage(cvGetSize(&src), IPL_DEPTH_8U, 3);
-        cvCopy(&src, cvResultado);
+    cv::Mat Api::getImageCamera2() {
 
-        return cvResultado;
+	cv::Mat cvResultado = this->image2.clone();
+	return cvResultado;
     }
 
     void Api::setMotorV(float motorV) {
@@ -128,15 +124,13 @@ namespace introrob {
 
     void Api::imageCameras2openCV() {
         pthread_mutex_lock(&this->controlGui);
-        cvReleaseImage(&imageCameraRight);
-        this->imageCameraRight = cvCreateImage(cvSize(imageData2->description->width, imageData2->description->height), 8, 3);
 
-        memcpy((unsigned char *) imageCameraRight->imageData, &(imageData2->pixelData[0]), imageCameraRight->width * imageCameraRight->height * 3);
+	// cv::Mat processing
+	this->imageCameraRight.create(imageData2->description->height, imageData2->description->width, CV_8UC3);
+	memcpy((unsigned char *) this->imageCameraRight.data, &(imageData2->pixelData[0]), this->imageCameraRight.cols*imageCameraRight.rows*3);
 
-        cvReleaseImage(&imageCameraLeft);
-        this->imageCameraLeft = cvCreateImage(cvSize(imageData1->description->width, imageData1->description->height), 8, 3);
-
-        memcpy((unsigned char *) imageCameraLeft->imageData, &(imageData1->pixelData[0]), imageCameraLeft->width * imageCameraLeft->height * 3);
+	this->imageCameraLeft.create(imageData1->description->height, imageData1->description->width, CV_8UC3);
+	memcpy((unsigned char *) this->imageCameraLeft.data, &(imageData1->pixelData[0]), this->imageCameraLeft.cols*imageCameraLeft.rows*3);
 
         /*
         colorspaces::Image::FormatPtr fmt1 = colorspaces::Image::Format::searchFormat(imageData1->description->format);
@@ -273,22 +267,7 @@ namespace introrob {
     void Api::showMyImage() {
         int i, j;
 
-        //IplImage src = *this->imageCameraLeft;
-/*
-        IplImage* cvResultado = cvCreateImage(cvGetSize(&src), IPL_DEPTH_8U, 3);
-        cvCopy(&src, cvResultado);
-        for (i = 0; i < cvResultado->width; i++) {
-            for (j = 0; j < cvResultado->height; j++) {
-                cvResultado->imageData[j * cvResultado->widthStep + i * cvResultado->nChannels] = this->imageCameraLeft->imageData[j * this->imageCameraLeft->widthStep + i * this->imageCameraLeft->nChannels + 2]; //R
-                cvResultado->imageData[j * cvResultado->widthStep + i * cvResultado->nChannels + 1] = this->imageCameraLeft->imageData[j * this->imageCameraLeft->widthStep + i * this->imageCameraLeft->nChannels + 1]; //R
-                cvResultado->imageData[j * cvResultado->widthStep + i * cvResultado->nChannels + 2] = this->imageCameraLeft->imageData[j * this->imageCameraLeft->widthStep + i * this->imageCameraLeft->nChannels]; //R
-            }
-        }
-*/
-
-        cvShowImage("DebuggingWin", this->imageCameraLeft);
-
-
+        imshow("DebuggingWin", this->imageCameraLeft);
 
     }
 

--- a/src/stable/components/introrob/API.h
+++ b/src/stable/components/introrob/API.h
@@ -27,8 +27,8 @@
 
 //#include "camera.h"
 #include <progeo/progeo.h>
-#include <cv.h>
-#include <highgui.h>
+#include <opencv2/core/core.hpp>
+#include <opencv2/highgui/highgui.hpp>
 #include <iostream>
 #include <Ice/Ice.h>
 #include <IceUtil/IceUtil.h>
@@ -72,8 +72,8 @@ namespace introrob {
         int getNumLasers();
         jderobot::IntSeq getDistancesLaser();
         jderobot::EncodersDataPtr getEncodersData();
-        IplImage* getImageCamera1();
-        IplImage* getImageCamera2();
+        cv::Mat getImageCamera1();
+        cv::Mat getImageCamera2();
 
         //SETS
         void setMotorV(float motorV);
@@ -104,8 +104,8 @@ namespace introrob {
         jderobot::Pose3DEncodersDataPtr Pose3Dencoders2;
         jderobot::Pose3DMotorsData* Pose3DmotorsData1;
         jderobot::Pose3DMotorsData* Pose3DmotorsData2;
-        colorspaces::Image* image1; // Image camera1 processed to manipulate with openCV
-        colorspaces::Image* image2; // Image camera2 processed to manipulate with openCV
+        cv::Mat image1; // Image camera1 processed to manipulate with openCV
+        cv::Mat image2; // Image camera2 processed to manipulate with openCV
         bool guiVisible;
         bool iterationControlActivated;
         //Variables used in NavigationAlgorithm
@@ -116,20 +116,20 @@ namespace introrob {
         bool segmentoPintado;
         int numlines;
         float extra_lines[MAX_LINES][9];
-        IplImage* imageOnCamera;
+        cv::Mat imageOnCamera;
         bool showImage;
         gint x_click_cameraleft, y_click_cameraleft, x_click_cameraright, y_click_cameraright;
         TPinHoleCamera myCamA, myCamB;
         Glib::RefPtr<Gdk::Pixbuf> imgBuff2, imgBuff;
         bool imagesReady;
         bool guiReady;
-        IplImage* imageCameraLeft;
-        IplImage* imageCameraRight;
+        cv::Mat imageCameraLeft;
+        cv::Mat imageCameraRight;
 
     private:
         //Variables used in NavigationAlgorithm
-        IplImage* imageCamera1;
-        IplImage* imageCamera2;
+        cv::Mat imageCamera1;
+        cv::Mat imageCamera2;
 
         struct XYZ {
             double x;

--- a/src/stable/components/introrob/MyAlgorithms.cpp
+++ b/src/stable/components/introrob/MyAlgorithms.cpp
@@ -157,20 +157,8 @@ namespace introrob {
         /*En el siguiente ejemplo se filtra el color rojo de la cámara izquierda para repintar esos píxeles a negro. Para visualizar el resultado
         debemos desplegar la ventana "WINDOW DEBUGGING" y pulsar PLAY para hacer correr nuestro código*/
         imageCameras2openCV(); //Esta función es necesario llamarla ANTES de trabajar con las imágenes de las cámaras.
-        IplImage src = *this->imageCameraLeft; //Imagen de la cámara izquierda
 
-        for (i = 0; i < src.width; i++) {
-            for (j = 0; j < src.height; j++) {
-                if (((int) (unsigned char) src.imageData[(j * src.width + i) * src.nChannels] > 120) &&
-                        ((int) (unsigned char) src.imageData[(j * src.width + i) * src.nChannels + 1] < 70) &&
-                        ((int) (unsigned char) src.imageData[(j * src.width + i) * src.nChannels + 2] < 70)) {
-                    cont++;
-                    src.imageData[(j * src.width + i) * src.nChannels] = 255; //R
-                    src.imageData[(j * src.width + i) * src.nChannels + 1] = 255; //G
-                    src.imageData[(j * src.width + i) * src.nChannels + 2] = 0; //B
-                }
-            }
-        }
+        cv::line(imageCameraLeft, cv::Point2d(0,0), cv::Point2d(imageCameraLeft.cols, imageCameraLeft.rows), cv::Scalar::all(255), 3);
 
         /* A continuacion se muestran las coordenadas de los puntos obtenidos tras hacer click en alguna de las camaras */
         //std::cout << x_click_cameraleft << std::endl; // Coordenada x del punto donde se ha hecho click en la camara izquierda

--- a/src/stable/components/introrob/control.cpp
+++ b/src/stable/components/introrob/control.cpp
@@ -44,8 +44,8 @@ namespace introrob {
 
         pthread_mutex_lock(&api->controlGui);
         api->imagesReady = FALSE;
-        api->imageData1 = this->cprx1->getImageData( this->cprx1->getImageFormat().at(0) );
-        api->imageData2 = this->cprx2->getImageData( this->cprx2->getImageFormat().at(0) );
+        api->imageData1 = this->cprx1->getImageData( colorspaces::ImageRGB8::FORMAT_RGB8.get()->name );
+        api->imageData2 = this->cprx2->getImageData( colorspaces::ImageRGB8::FORMAT_RGB8.get()->name );
         if (api->guiReady) {
             createImage(api);
             createImage2(api);
@@ -59,10 +59,9 @@ namespace introrob {
     }
 
     void Control::createImage(Api *api) {
-        cvReleaseImage(&image);
-        this->image = cvCreateImage(cvSize(api->imageData1->description->width, api->imageData1->description->height), 8, 3);
 
-        memcpy((unsigned char *) image->imageData, &(api->imageData1->pixelData[0]), image->width * image->height * 3);
+        this->image.create(api->imageData1->description->height, api->imageData1->description->width, CV_8UC3);
+	memcpy((unsigned char *) this->image.data, &(api->imageData1->pixelData[0]), this->image.cols*image.rows*3);
 /*
         colorspaces::Image::FormatPtr fmt = colorspaces::Image::Format::searchFormat(api->imageData1->description->format);
 
@@ -70,35 +69,34 @@ namespace introrob {
             throw "Format not supported";
 */
         api->imgBuff =
-                Gdk::Pixbuf::create_from_data((const guint8*) this->image->imageData,
+                Gdk::Pixbuf::create_from_data((const guint8*) this->image.data,
                 Gdk::COLORSPACE_RGB,
                 false,
-                this->image->depth,
-                this->image->width,
-                this->image->height,
-                this->image->widthStep);
+                8, //this->image.depth,
+                this->image.cols,
+                this->image.rows,
+                this->image.step);
 
     }
 
     void Control::createImage2(Api *api) {
-        cvReleaseImage(&image2);
-        this->image2 = cvCreateImage(cvSize(api->imageData2->description->width, api->imageData2->description->height), 8, 3);
 
-        memcpy((unsigned char *) image2->imageData, &(api->imageData2->pixelData[0]), image2->width * image2->height * 3);
+        this->image2.create(api->imageData2->description->height, api->imageData2->description->width, CV_8UC3);
+	memcpy((unsigned char *) this->image2.data, &(api->imageData2->pixelData[0]), this->image2.cols*image2.rows*3);
 /*
         colorspaces::Image::FormatPtr fmt2 = colorspaces::Image::Format::searchFormat(api->imageData2->description->format);
 
         if (!fmt2)
             throw "Format not supported";
 */
-        api->imgBuff2 =
-                Gdk::Pixbuf::create_from_data((const guint8*) this->image2->imageData,
+         api->imgBuff2 =
+                Gdk::Pixbuf::create_from_data((const guint8*) this->image2.data,
                 Gdk::COLORSPACE_RGB,
                 false,
-                this->image2->depth,
-                this->image2->width,
-                this->image2->height,
-                this->image2->widthStep);
+                8, //this->image2.depth,
+                this->image2.cols,
+                this->image2.rows,
+                this->image2.step);
     }
 
     // Send the actuators info to Gazebo with ICE

--- a/src/stable/components/introrob/control.h
+++ b/src/stable/components/introrob/control.h
@@ -68,8 +68,8 @@ namespace introrob {
         void createImage(Api *api);
         void createImage2(Api *api);
 
-        IplImage* image;
-        IplImage* image2;
+        cv::Mat image;
+        cv::Mat image2;
 
 
     }; //class

--- a/src/stable/components/introrob/drawarea.h
+++ b/src/stable/components/introrob/drawarea.h
@@ -27,7 +27,6 @@
 
 #include <string>
 #include <iostream>
-#include <cv.h>
 #include <pthread.h>
 #include <gtkmm.h>
 #include <gtkglmm.h>

--- a/src/stable/components/introrob/gui.h
+++ b/src/stable/components/introrob/gui.h
@@ -23,7 +23,6 @@
 #define INTROROB_GUI_H
 
 #include <math.h>
-#include <cv.h>
 #include <GL/gl.h>
 #include <GL/glu.h>
 #include <GL/glut.h>
@@ -72,7 +71,7 @@ namespace introrob {
         void updateCameras(Api *api);
         void resetAPI(Api *api);
         void setDestino();
-        void prepare2draw(IplImage &image);
+        void prepare2draw(cv::Mat image);
         void calculate_projection_line(HPoint2D pix, int idcamera);
         void get3DPositionZ(TPinHoleCamera * camera, HPoint3D &res, HPoint2D in, float Z);
         void add_line(float x0, float y0, float z0, float x1, float y1, float z1, int color);


### PR DESCRIPTION
I've fixed some issues related to the new camera and image interfaces in the pioneer gazebo plugins and introrob. I've also refactorized introrob with the newer cv::Mat image format (it was ussing IplImage*). This change is in another pull request #44 which I'm going to close, so we don't have a mesh with the pull requests.
Now we can load the pioneer model in gazebo and launch introrob with no problems in the lastest gazebo version (5.1.0).
I'm going to refactor the nao plugins aswell so we can load the nao model too soon.