### PR TITLE
QuadrotorPlugin: Version 5 navdata field vehicle returns 10.

### DIFF
--- a/src/stable/components/gazeboserver/plugins/quadrotor/interfaces/navdatai.cpp
+++ b/src/stable/components/gazeboserver/plugins/quadrotor/interfaces/navdatai.cpp
@@ -74,7 +74,7 @@ namespace navdata
 /*		if (IS_ARDRONE2){
 			data->vehicle=1;
 		}else{*/
-			data->vehicle=0;
+			data->vehicle=10;
 //		}
 		
 /*		data->batteryPercent=navdata_raw.navdata_demo.vbat_flying_percentage;


### PR DESCRIPTION
Hi JdeRobot,

I've made a little change on the quadrotor's drivers. The navdata structure returned with the getNavData method on the navdatai.cpp file now contains 10 instead of 0. This change is usefull to distinguish the simulated ArDrone from the real one.

Best regards,

Daniel