### PR TITLE
Issue #79: Solved colorspacesmm issue on quadrotor plugins

### DIFF
--- a/src/stable/components/gazeboserver/plugins/quadrotor/CMakeLists.txt
+++ b/src/stable/components/gazeboserver/plugins/quadrotor/CMakeLists.txt
@@ -28,6 +28,7 @@ target_link_libraries(quadrotorplugin
 	IceUtil
 	${libxmlpp_LIBRARIES}
     JderobotInterfaces
+    colorspacesmm
 	${GAZEBO_libraries} 
 )
 


### PR DESCRIPTION
The CMakeLists.txt file now includes colorspacesmm on the quadrotorplugin target_link_libraries section.