### PR TITLE
Fix #116

### DIFF
--- a/src/stable/components/gazeboserver/plugins/kinect/CMakeLists.txt
+++ b/src/stable/components/gazeboserver/plugins/kinect/CMakeLists.txt
@@ -21,9 +21,10 @@ target_link_libraries(kinectPlugin
     JderobotInterfaces
     jderobotutil
     ${GAZEBO_libraries} 
-    ${pcl_LIBRARIES}  
+    ${PCL_LIBRARIES}  
     ${OpenCV_LIBRARIES}
     ${ZeroCIce_LIBRARIES}
+    colorspacesmm
 )
 
 INSTALL (TARGETS kinectPlugin DESTINATION share/jderobot/gazebo/plugins/kinect/ )


### PR DESCRIPTION
Fix #116: failed to load gazebo kinect plugin libkinectPlugin.so due to undefined symbol issues.