### PR TITLE
Fix #119: RgbdViewer crashes with kinect plugin

### DIFF
--- a/src/stable/components/gazeboserver/plugins/kinect/kinectPlugin.cc
+++ b/src/stable/components/gazeboserver/plugins/kinect/kinectPlugin.cc
@@ -282,10 +282,13 @@ class CameraI: virtual public jderobot::Camera {
 		CameraI(std::string propertyPrefix, gazebo::DepthCameraPlugin* camera, std::string format)
 			   : prefix(propertyPrefix), cameraI(camera) {
 		
-			std::cout << "Constructor CameraI" << std::endl;
+			std::cout << "Constructor CameraRGB" << std::endl;
 
 			imageDescription = (new jderobot::ImageDescription());
 			mFormats.push_back(format);
+
+            cameraDescription = (new jderobot::CameraDescription ());
+            cameraDescription->name = propertyPrefix;
 
         replyTask = new ReplyTask(this);
 		    replyTask->start(); // my own thread
@@ -447,6 +450,10 @@ class CameraII: virtual public jderobot::Camera {
 
 			imageDescription = (new jderobot::ImageDescription());
 			mFormats.push_back(format);
+
+            cameraDescription = (new jderobot::CameraDescription ());
+            cameraDescription->name = propertyPrefix;
+
         	replyTask = new ReplyTask(this);
 		    replyTask->start(); // my own thread
 		  


### PR DESCRIPTION
RgbdViewer crashes after throwing NullHandleExecption with kinect plugin. See [here](http://jderobot-developer-list.2315034.n4.nabble.com/JdeRobot-rgbdViwer-won-t-run-after-throwing-an-exception-td4642690.html) for more discussions. 