### PR TITLE
Fix Python/Numpy future warning for `img != None`.

### DIFF
--- a/src/stable/components/introrob_py/gui/cameraWidget.py
+++ b/src/stable/components/introrob_py/gui/cameraWidget.py
@@ -57,7 +57,7 @@ class CameraWidget(QtGui.QWidget):
     def updateImage(self):
 
         img = self.winParent.getSensor().getImage()
-        if img != None:
+        if img is not None:
             image = QtGui.QImage(img.data, img.shape[1], img.shape[0], img.shape[1]*img.shape[2], QtGui.QImage.Format_RGB888);
         
             if img.shape[1]==self.IMAGE_COLS_MAX:

--- a/src/stable/components/introrob_py/gui/colorFilterWidget.py
+++ b/src/stable/components/introrob_py/gui/colorFilterWidget.py
@@ -57,14 +57,14 @@ class ColorFilterWidget(QtGui.QWidget, Ui_Form):
         else:
             img = self.winParent.getSensor().getImage()
 
-        if img != None:
+        if img is not None:
             image = QtGui.QImage(img.data, img.shape[1], img.shape[0], img.shape[1]*img.shape[2], QtGui.QImage.Format_RGB888);
             self.inputImage.setPixmap(QtGui.QPixmap.fromImage(image))
 
 
     def setThresoldImage(self):
         img = self.winParent.getSensor().getThresoldImage()
-        if img != None:
+        if img is not None:
             image = QtGui.QImage(img.data, img.shape[1], img.shape[0], img.shape[1], QtGui.QImage.Format_Indexed8)
             self.outputFilterImage.setPixmap(QtGui.QPixmap.fromImage(image))
 


### PR DESCRIPTION
Fix Python/Numpy future warning for `img != None`.
Use `img is not None` instead.

By the moment Python complains it (but in future no more):
FutureWarning: comparison to `None` will result in an elementwise object comparison in the future.

See http://lists.ipython.scipy.org/pipermail/numpy-discussion/2014-September/071235.html