### PR TITLE
fix #206: install from binary dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,7 +163,7 @@ add_subdirectory (${CMAKE_CURRENT_SOURCE_DIR}/src)
 #                 #
 ###################
 
-INSTALL(FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/stable/interfaces/libJderobotInterfaces.so DESTINATION /usr/local/lib/jderobot)
+INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/src/stable/interfaces/libJderobotInterfaces.so DESTINATION /usr/local/lib/jderobot)
 
 # Install python files
 FILE(GLOB_RECURSE HEADERS_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/stable/interfaces/python/jderobot/*py)


### PR DESCRIPTION
Just some reminders:
* CMAKE_BINARY_DIR == pwd of cmake
* CMAKE_SOURCE_DIR == cmake target dir

So cmake . --> CMAKE_BINARY_DIR==CMAKE_SOURCE_DIR
But not cmake ..

----
Related to #206 
This change should be validated by @chanfr