### PR TITLE
Outsource build (2): interfaces + gazeboserver/plugins

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ SET( LIBS_NEEDED  colorspaces jderobotutil progeo pioneer fuzzylib visionlib par
 # Create directories if necessary
 file(MAKE_DIRECTORY ${INTERFACES_PYTHON_DIR})
 file(MAKE_DIRECTORY ${INTERFACES_JAVA_DIR})
+file(MAKE_DIRECTORY ${INTERFACES_CPP_DIR})
 
 # MACRO to get the list of subdirectories
 macro(list_subdirectories retval curdir return_relative)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,12 +174,12 @@ ENDFOREACH(header)
 INSTALL(FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/stable/interfaces/python/jderobot/jderobot/__init__.py DESTINATION /usr/lib/python2.7/jderobot/)
 
 # install all libraries 
-FILE(GLOB LIB_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/stable/libs/*/*.so*)
+FILE(GLOB LIB_FILES ${CMAKE_CURRENT_BINARY_DIR}/src/stable/libs/*/*.so*)
 FOREACH (lib ${LIB_FILES})
 	INSTALL (FILES ${lib} DESTINATION /usr/local/lib/jderobot)
 ENDFOREACH(lib)
 
-FILE(GLOB LIB_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/stable/libs/visionlib/*/*.so*)
+FILE(GLOB LIB_FILES ${CMAKE_CURRENT_BINARY_DIR}/src/stable/libs/visionlib/*/*.so*)
 FOREACH (lib ${LIB_FILES})
 	INSTALL (FILES ${lib} DESTINATION /usr/local/lib/jderobot)
 ENDFOREACH(lib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,8 +213,10 @@ FOREACH (currentBin ${LIST_COMPONENTS})
 ENDFOREACH(currentBin)
 
 # Install interfaces headers
-FILE(GLOB HEADER_INTERFACE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/stable/interfaces/cpp/jderobot/*.h)
-INSTALL (FILES ${HEADER_INTERFACE_FILES} DESTINATION /usr/local/include/jderobot)
+INSTALL(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/src/stable/interfaces/cpp/jderobot/
+    DESTINATION /usr/local/include/jderobot
+    FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp"
+)
 
 # Install slice
 FILE(GLOB SLICE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/stable/interfaces/slice/jderobot/*.ice)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,12 +166,12 @@ add_subdirectory (${CMAKE_CURRENT_SOURCE_DIR}/src)
 INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/src/stable/interfaces/libJderobotInterfaces.so DESTINATION /usr/local/lib/jderobot)
 
 # Install python files
-FILE(GLOB_RECURSE HEADERS_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/stable/interfaces/python/jderobot/*py)
+FILE(GLOB_RECURSE HEADERS_FILES ${CMAKE_CURRENT_BINARY_DIR}/src/stable/interfaces/python/*py)
 FOREACH(header ${HEADERS_FILES})
 	INSTALL(FILES ${header} DESTINATION /usr/lib/python2.7/jderobot/)
 ENDFOREACH(header)
 
-INSTALL(FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/stable/interfaces/python/jderobot/jderobot/__init__.py DESTINATION /usr/lib/python2.7/jderobot/)
+INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/src/stable/interfaces/python/jderobot/__init__.py DESTINATION /usr/lib/python2.7/jderobot/)
 
 # install all libraries 
 FILE(GLOB LIB_FILES ${CMAKE_CURRENT_BINARY_DIR}/src/stable/libs/*/*.so*)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,11 +26,11 @@ endif()
 SET(gladedir ./)
 SET( DEPS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/Deps) # Directory where the dependencies are there
 # Folder with ICE cpp interfaces
-SET( INTERFACES_CPP_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/stable/interfaces/cpp/jderobot ${CMAKE_CURRENT_SOURCE_DIR}/src/stable/interfaces/cpp/)
+SET( INTERFACES_CPP_DIR ${CMAKE_CURRENT_BINARY_DIR}/src/stable/interfaces/cpp/jderobot ${CMAKE_CURRENT_BINARY_DIR}/src/stable/interfaces/cpp/)
 # Folder with ICE python interfaces
-SET( INTERFACES_PYTHON_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/stable/interfaces/python/jderobot ${CMAKE_CURRENT_SOURCE_DIR}/src/stable/interfaces/python/)
+SET( INTERFACES_PYTHON_DIR ${CMAKE_CURRENT_BINARY_DIR}/src/stable/interfaces/python/jderobot ${CMAKE_CURRENT_BINARY_DIR}/src/stable/interfaces/python/)
 # Folder with ICE java interfaces
-SET( INTERFACES_JAVA_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/stable/interfaces/java/jderobot ${CMAKE_CURRENT_SOURCE_DIR}/src/stable/interfaces/java/)
+SET( INTERFACES_JAVA_DIR ${CMAKE_CURRENT_BINARY_DIR}/src/stable/interfaces/java/jderobot ${CMAKE_CURRENT_BINARY_DIR}/src/stable/interfaces/java/)
 # Folder JdeRobot libraries 
 SET( LIBS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/stable/libs) 
 # Folder ICE interface definitions

--- a/src/stable/components/gazeboserver/CMakeLists.txt
+++ b/src/stable/components/gazeboserver/CMakeLists.txt
@@ -1,6 +1,6 @@
 IF (GAZEBO_INCLUDE_DIRS)
 
-	add_subdirectory (${CMAKE_CURRENT_SOURCE_DIR}/plugins ${CMAKE_CURRENT_SOURCE_DIR}/plugins)
+	add_subdirectory (${CMAKE_CURRENT_SOURCE_DIR}/plugins)
 
 
 	## INSTALL ##

--- a/src/stable/interfaces/CMakeLists.txt
+++ b/src/stable/interfaces/CMakeLists.txt
@@ -12,10 +12,33 @@ TARGET_LINK_LIBRARIES(JderobotInterfaces ${ice2_LIBRARIES})
 
 else()
 
+### CMakeCache build control
+if (NOT DEFINED build_interfaces_cpp)
+    set(build_interfaces_cpp "ON" CACHE BOOL "Build Ice interfaces for CPP")
+endif()
+if (NOT DEFINED build_interfaces_java)
+    set(build_interfaces_java "ON" CACHE BOOL "Build Ice interfaces for Java")
+endif()
+if (NOT DEFINED build_interfaces_python)
+    set(build_interfaces_python "ON" CACHE BOOL "Build Ice interfaces for Python")
+endif()
+
+message(STATUS "Building ICE Interfaces for:")
+if (build_interfaces_cpp)
+    message(STATUS "\tCPP")
+endif()
+if (build_interfaces_java)
+    message(STATUS "\tJava")
+endif()
+if (build_interfaces_python)
+    message(STATUS "\tPython")
+endif()
+
+
 
 set(SLICE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/slice)
-set(SLICE_CPP_DIR ${CMAKE_CURRENT_BINARY_DIR}/cpp)
-set(SLICE_PY_DIR ${CMAKE_CURRENT_BINARY_DIR}/python)
+set(SLICE_CPP_DIR  ${CMAKE_CURRENT_BINARY_DIR}/cpp)
+set(SLICE_PY_DIR   ${CMAKE_CURRENT_BINARY_DIR}/python)
 set(SLICE_JAVA_DIR ${CMAKE_CURRENT_BINARY_DIR}/java)
 
 FILE(GLOB_RECURSE SLICE_FILES
@@ -23,70 +46,63 @@ FILE(GLOB_RECURSE SLICE_FILES
     "*.ice"
 )
 
-#message(STATUS "SLICE_FILES ${SLICE_FILES}")
-#message(STATUS "CMAKE_CURRENT_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}")
-
-message(STATUS "Building SLICE Interfaces for CPP")
+### Trick to publich .ice files into CMake's sources
+file(GLOB_RECURSE SLICE_DEFINITIONS "slice/**.ice")
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/dummy.c "")
+add_library(JderobotInterfaces_Definitions ${CMAKE_CURRENT_BINARY_DIR}/dummy.c ${SLICE_DEFINITIONS})
 
 
 foreach(slice_rel_path ${SLICE_FILES})
     get_filename_component(slice_name ${slice_rel_path} NAME_WE)
     get_filename_component(slice_file_name ${slice_rel_path} NAME)
-    get_filename_component(slice_rel_dir   ${slice_rel_path} PATH)
-    set(slice_abs_path  ${SLICE_DIRECTORY}/${slice_rel_path})
-    set(slice_abs_dir  ${SLICE_DIRECTORY}/${slice_rel_dir})
+    get_filename_component(slice_rel_dir   ${slice_rel_path} PATH) # PATH for cmake <= 2.8.11
+    set(slice_abs_path  ${SLICE_DIRECTORY}/${slice_rel_path}) # get_filename_component() relative to absolute relies in cmake_current_source_dir. Not valid fot his setup
 
 #    message(STATUS "slice_name ${slice_name}")
-#    message(STATUS "slice_file_name ${slice_file_name}")
 #    message(STATUS "slice_rel_dir ${slice_rel_dir}")
 #    message(STATUS "slice_abs_path ${slice_abs_path}")
-#    message(STATUS "slice_abs_dir ${slice_abs_dir}")
 
     ### CPP
-    set(target_directory ${SLICE_CPP_DIR}/${slice_rel_dir})
-    file(MAKE_DIRECTORY ${target_directory})
-
-if(DEFINED SLICE_ON_MAKE)
-    add_custom_command(
-        OUTPUT ${target_directory}/${slice_name}.h ${target_directory}/${slice_name}.cpp
-        WORKING_DIRECTORY ${target_directory}
-        COMMAND slice2cpp ${slice_file_name} -I${SLICE_DIRECTORY} -I${SLICE_CPP_DIR} --output-dir ${target_directory} --include-dir ${slice_rel_dir}
-        COMMENT "Ice: Processing ${slice_name} for CPP"
-    )
-else() # SLICE_ON_CMAKE
-    execute_process(
-        WORKING_DIRECTORY ${target_directory}
-        COMMAND slice2cpp ${slice_abs_path} -I${SLICE_DIRECTORY} --output-dir ${target_directory} --include-dir ${slice_rel_dir}
-    )
-endif()
-    #LIST(APPEND SLICE_CPP_GENERATED ${target_directory}/${slice_name}.h)
-    LIST(APPEND SLICE_CPP_GENERATED ${target_directory}/${slice_name}.cpp)
-
+    if (build_interfaces_cpp)
+        set(target_directory ${SLICE_CPP_DIR}/${slice_rel_dir})
+        file(MAKE_DIRECTORY ${target_directory})
+        execute_process(
+            WORKING_DIRECTORY ${target_directory}
+            COMMAND slice2cpp ${slice_abs_path} -I${SLICE_DIRECTORY} --output-dir ${target_directory} --include-dir ${slice_rel_dir}
+            INPUT_FILE ${slice_abs_path}
+        )
+        #LIST(APPEND SLICE_CPP_GENERATED ${target_directory}/${slice_name}.h) # fetching .h files relies on include_directories()
+        LIST(APPEND SLICE_CPP_GENERATED ${target_directory}/${slice_name}.cpp)
+    endif()
 
     ### Python
-    set(target_directory ${SLICE_PY_DIR}/${slice_rel_dir})
-    file(MAKE_DIRECTORY ${target_directory})
-    execute_process(
-        WORKING_DIRECTORY ${SLICE_PY_DIR}
-        COMMAND slice2py ${slice_abs_path} -I${SLICE_DIRECTORY} --output-dir ${SLICE_PY_DIR} --all
-        # py files will be placed at ${SLICE_PY_DIR}
-        # __init__.py will be placed at ${target_directory} (creates a directory for each module)
-        # tested but invalid: --prefix (not a '--include-dir' equivalent)
-
-    )
+    if (build_interfaces_python)
+        set(target_directory ${SLICE_PY_DIR}/${slice_rel_dir})
+        file(MAKE_DIRECTORY ${target_directory})
+        execute_process(
+            WORKING_DIRECTORY ${SLICE_PY_DIR}
+            COMMAND slice2py ${slice_abs_path} -I${SLICE_DIRECTORY} --output-dir ${SLICE_PY_DIR} --all
+            # py files will be placed at ${SLICE_PY_DIR}
+            # __init__.py will be placed at ${target_directory} (creates a directory for each module)
+            # tested but invalid: --prefix (not a '--include-dir' equivalent)
+            INPUT_FILE ${slice_abs_path}
+        )
+    endif()
 
     ### Java
-    set(target_directory ${SLICE_JAVA_DIR}/${slice_rel_dir})
-    file(MAKE_DIRECTORY ${target_directory})
-    execute_process(
-        WORKING_DIRECTORY ${SLICE_JAVA_DIR}
-        COMMAND slice2java ${slice_abs_path} -I${SLICE_DIRECTORY} --output-dir ${SLICE_JAVA_DIR}
-    )
+    if (build_interfaces_java)
+        set(target_directory ${SLICE_JAVA_DIR}/${slice_rel_dir})
+        file(MAKE_DIRECTORY ${target_directory})
+        execute_process(
+            WORKING_DIRECTORY ${SLICE_JAVA_DIR}
+            COMMAND slice2java ${slice_abs_path} -I${SLICE_DIRECTORY} --output-dir ${SLICE_JAVA_DIR}
+            INPUT_FILE ${slice_abs_path}
+        )
+    endif()
 
 endforeach()
 
 
-unset(slice_abs_dir)
 unset(slice_abs_path)
 unset(slice_rel_dir)
 unset(slice_file_name)
@@ -96,8 +112,10 @@ unset(SLICE_DIRECTORY)
 
 
 ### CPP
-include_directories(${SLICE_CPP_DIR})
-add_library (JderobotInterfaces SHARED ${SLICE_CPP_GENERATED})
-target_link_libraries(JderobotInterfaces ${ice2_LIBRARIES})
+if (build_interfaces_cpp)
+    include_directories(${SLICE_CPP_DIR})
+    add_library (JderobotInterfaces SHARED ${SLICE_CPP_GENERATED})
+    target_link_libraries(JderobotInterfaces ${ice2_LIBRARIES})
+endif()
 
 endif(NOT DEFINED SLICE_NEW_STYLE)

--- a/src/stable/interfaces/CMakeLists.txt
+++ b/src/stable/interfaces/CMakeLists.txt
@@ -68,15 +68,15 @@ endif()
     file(MAKE_DIRECTORY ${target_directory})
     execute_process(
         WORKING_DIRECTORY ${SLICE_PY_DIR}
-        COMMAND slice2py ${slice_abs_path} -I${SLICE_DIRECTORY} --output-dir ${target_directory}
+        COMMAND slice2py ${slice_abs_path} -I${SLICE_DIRECTORY} --output-dir ${SLICE_PY_DIR}
     )
 
     ### Java
     set(target_directory ${SLICE_JAVA_DIR}/${slice_rel_dir})
     file(MAKE_DIRECTORY ${target_directory})
     execute_process(
-        WORKING_DIRECTORY ${SLICE_PY_DIR}
-        COMMAND slice2java ${slice_abs_path} -I${SLICE_DIRECTORY} --output-dir ${target_directory}
+        WORKING_DIRECTORY ${SLICE_JAVA_DIR}
+        COMMAND slice2java ${slice_abs_path} -I${SLICE_DIRECTORY} --output-dir ${SLICE_JAVA_DIR}
     )
 
 endforeach()

--- a/src/stable/interfaces/CMakeLists.txt
+++ b/src/stable/interfaces/CMakeLists.txt
@@ -68,7 +68,11 @@ endif()
     file(MAKE_DIRECTORY ${target_directory})
     execute_process(
         WORKING_DIRECTORY ${SLICE_PY_DIR}
-        COMMAND slice2py ${slice_abs_path} -I${SLICE_DIRECTORY} --output-dir ${SLICE_PY_DIR}
+        COMMAND slice2py ${slice_abs_path} -I${SLICE_DIRECTORY} --output-dir ${SLICE_PY_DIR} --all
+        # py files will be placed at ${SLICE_PY_DIR}
+        # __init__.py will be placed at ${target_directory} (creates a directory for each module)
+        # tested but invalid: --prefix (not a '--include-dir' equivalent)
+
     )
 
     ### Java

--- a/src/stable/interfaces/CMakeLists.txt
+++ b/src/stable/interfaces/CMakeLists.txt
@@ -1,3 +1,6 @@
+set(SLICE_NEW_STYLE "ON")
+if (NOT DEFINED SLICE_NEW_STYLE)
+
 include (${CMAKE_CURRENT_LIST_DIR}/slice/CMakeLists.txt)
 
 include_directories(
@@ -6,3 +9,91 @@ include_directories(
 )
 add_library (JderobotInterfaces SHARED ${SOURCE_FILES} ${ICE_FILES})
 TARGET_LINK_LIBRARIES(JderobotInterfaces ${ice2_LIBRARIES})
+
+else()
+
+
+set(SLICE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/slice)
+set(SLICE_CPP_DIR ${CMAKE_CURRENT_BINARY_DIR}/cpp)
+set(SLICE_PY_DIR ${CMAKE_CURRENT_BINARY_DIR}/python)
+set(SLICE_JAVA_DIR ${CMAKE_CURRENT_BINARY_DIR}/java)
+
+FILE(GLOB_RECURSE SLICE_FILES
+    RELATIVE ${SLICE_DIRECTORY}
+    "*.ice"
+)
+
+#message(STATUS "SLICE_FILES ${SLICE_FILES}")
+#message(STATUS "CMAKE_CURRENT_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}")
+
+message(STATUS "Building SLICE Interfaces for CPP")
+
+
+foreach(slice_rel_path ${SLICE_FILES})
+    get_filename_component(slice_name ${slice_rel_path} NAME_WE)
+    get_filename_component(slice_file_name ${slice_rel_path} NAME)
+    get_filename_component(slice_rel_dir   ${slice_rel_path} PATH)
+    set(slice_abs_path  ${SLICE_DIRECTORY}/${slice_rel_path})
+    set(slice_abs_dir  ${SLICE_DIRECTORY}/${slice_rel_dir})
+
+#    message(STATUS "slice_name ${slice_name}")
+#    message(STATUS "slice_file_name ${slice_file_name}")
+#    message(STATUS "slice_rel_dir ${slice_rel_dir}")
+#    message(STATUS "slice_abs_path ${slice_abs_path}")
+#    message(STATUS "slice_abs_dir ${slice_abs_dir}")
+
+    ### CPP
+    set(target_directory ${SLICE_CPP_DIR}/${slice_rel_dir})
+    file(MAKE_DIRECTORY ${target_directory})
+
+if(DEFINED SLICE_ON_MAKE)
+    add_custom_command(
+        OUTPUT ${target_directory}/${slice_name}.h ${target_directory}/${slice_name}.cpp
+        WORKING_DIRECTORY ${target_directory}
+        COMMAND slice2cpp ${slice_file_name} -I${SLICE_DIRECTORY} -I${SLICE_CPP_DIR} --output-dir ${target_directory} --include-dir ${slice_rel_dir}
+        COMMENT "Ice: Processing ${slice_name} for CPP"
+    )
+else() # SLICE_ON_CMAKE
+    execute_process(
+        WORKING_DIRECTORY ${target_directory}
+        COMMAND slice2cpp ${slice_abs_path} -I${SLICE_DIRECTORY} --output-dir ${target_directory} --include-dir ${slice_rel_dir}
+    )
+endif()
+    #LIST(APPEND SLICE_CPP_GENERATED ${target_directory}/${slice_name}.h)
+    LIST(APPEND SLICE_CPP_GENERATED ${target_directory}/${slice_name}.cpp)
+
+
+    ### Python
+    set(target_directory ${SLICE_PY_DIR}/${slice_rel_dir})
+    file(MAKE_DIRECTORY ${target_directory})
+    execute_process(
+        WORKING_DIRECTORY ${SLICE_PY_DIR}
+        COMMAND slice2py ${slice_abs_path} -I${SLICE_DIRECTORY} --output-dir ${target_directory}
+    )
+
+    ### Java
+    set(target_directory ${SLICE_JAVA_DIR}/${slice_rel_dir})
+    file(MAKE_DIRECTORY ${target_directory})
+    execute_process(
+        WORKING_DIRECTORY ${SLICE_PY_DIR}
+        COMMAND slice2java ${slice_abs_path} -I${SLICE_DIRECTORY} --output-dir ${target_directory}
+    )
+
+endforeach()
+
+
+unset(slice_abs_dir)
+unset(slice_abs_path)
+unset(slice_rel_dir)
+unset(slice_file_name)
+unset(slice_name)
+unset(target_directory)
+unset(SLICE_DIRECTORY)
+
+
+### CPP
+include_directories(${SLICE_CPP_DIR})
+add_library (JderobotInterfaces SHARED ${SLICE_CPP_GENERATED})
+target_link_libraries(JderobotInterfaces ${ice2_LIBRARIES})
+
+endif(NOT DEFINED SLICE_NEW_STYLE)

--- a/src/stable/interfaces/slice/jderobot/body.ice
+++ b/src/stable/interfaces/slice/jderobot/body.ice
@@ -21,7 +21,7 @@
 #ifndef BODY_ICE
 #define BODY_ICE
 
-#include <common.ice>
+#include <jderobot/common.ice>
 
 module jderobot{  
 

--- a/src/stable/interfaces/slice/jderobot/bodyencoders.ice
+++ b/src/stable/interfaces/slice/jderobot/bodyencoders.ice
@@ -21,8 +21,8 @@
 #ifndef BODYENCODERS_ICE
 #define BODYENCODERS_ICE
 
-#include <common.ice>
-#include <body.ice>
+#include <jderobot/common.ice>
+#include <jderobot/body.ice>
 
 module jderobot{  
 

--- a/src/stable/interfaces/slice/jderobot/bodymotors.ice
+++ b/src/stable/interfaces/slice/jderobot/bodymotors.ice
@@ -21,8 +21,8 @@
 #ifndef BODYMOTORS_ICE
 #define BODYMOTORS_ICE
 
-#include <common.ice>
-#include <body.ice>
+#include <jderobot/common.ice>
+#include <jderobot/body.ice>
 
 module jderobot{  
 

--- a/src/stable/interfaces/slice/jderobot/bodymovements.ice
+++ b/src/stable/interfaces/slice/jderobot/bodymovements.ice
@@ -21,8 +21,8 @@
 #ifndef BODYMOVEMENTS_ICE
 #define BODYMOVEMENTS_ICE
 
-#include <common.ice>
-#include <body.ice>
+#include <jderobot/common.ice>
+#include <jderobot/body.ice>
 
 module jderobot{  
 

--- a/src/stable/interfaces/slice/jderobot/camera.ice
+++ b/src/stable/interfaces/slice/jderobot/camera.ice
@@ -24,7 +24,7 @@
 #define CAMERA_ICE
 
 
-#include <image.ice>
+#include <jderobot/image.ice>
 
 module jderobot{
   /**

--- a/src/stable/interfaces/slice/jderobot/common.ice
+++ b/src/stable/interfaces/slice/jderobot/common.ice
@@ -1,9 +1,9 @@
 #ifndef COMMON_ICE
 #define COMMON_ICE
 
-#include <datetime.ice>
-#include <exceptions.ice>
-#include <containers.ice>
+#include <jderobot/datetime.ice>
+#include <jderobot/exceptions.ice>
+#include <jderobot/containers.ice>
 
 module jderobot{
 }; /*module*/

--- a/src/stable/interfaces/slice/jderobot/encoders.ice
+++ b/src/stable/interfaces/slice/jderobot/encoders.ice
@@ -22,7 +22,7 @@
 #ifndef ENCODERS_ICE
 #define ENCODERS_ICE
 
-#include <common.ice>
+#include <jderobot/common.ice>
 
 
 module jderobot{  

--- a/src/stable/interfaces/slice/jderobot/genericData.ice
+++ b/src/stable/interfaces/slice/jderobot/genericData.ice
@@ -22,7 +22,7 @@
 #ifndef GENERICDATA_ICE
 #define GENERICDATA_ICE
 
-#include <common.ice>
+#include <jderobot/common.ice>
 
 
 module jderobot{  

--- a/src/stable/interfaces/slice/jderobot/image.ice
+++ b/src/stable/interfaces/slice/jderobot/image.ice
@@ -24,7 +24,7 @@
 #ifndef IMAGE_ICE
 #define IMAGE_ICE
 
-#include <common.ice>
+#include <jderobot/common.ice>
 
 
 module jderobot{  

--- a/src/stable/interfaces/slice/jderobot/laser.ice
+++ b/src/stable/interfaces/slice/jderobot/laser.ice
@@ -22,7 +22,7 @@
 #ifndef LASER_ICE
 #define LASER_ICE
 
-#include <common.ice>
+#include <jderobot/common.ice>
 
 
 module jderobot{  

--- a/src/stable/interfaces/slice/jderobot/motors.ice
+++ b/src/stable/interfaces/slice/jderobot/motors.ice
@@ -22,7 +22,7 @@
 #ifndef MOTORS_ICE
 #define MOTORS_ICE
 
-#include <common.ice>
+#include <jderobot/common.ice>
 
 module jderobot{  
 

--- a/src/stable/interfaces/slice/jderobot/namingService.ice
+++ b/src/stable/interfaces/slice/jderobot/namingService.ice
@@ -23,7 +23,7 @@
 #ifndef NAMING_SERVICE_ICE
 #define NAMING_SERVICE_ICE
 
-#include <common.ice>
+#include <jderobot/common.ice>
 
 module jderobot {
 

--- a/src/stable/interfaces/slice/jderobot/naofollowball.ice
+++ b/src/stable/interfaces/slice/jderobot/naofollowball.ice
@@ -22,7 +22,7 @@
 #ifndef NAOFOLLOWBALL_ICE
 #define NAOFOLLOWBALL_ICE
 
-#include <common.ice>
+#include <jderobot/common.ice>
 
 module jderobot {
     

--- a/src/stable/interfaces/slice/jderobot/naomotions.ice
+++ b/src/stable/interfaces/slice/jderobot/naomotions.ice
@@ -22,7 +22,7 @@
 #ifndef NAOMOTIONS_ICE
 #define NAOMOTIONS_ICE
 
-#include <common.ice>
+#include <jderobot/common.ice>
 
 module jderobot {
     

--- a/src/stable/interfaces/slice/jderobot/pose3d.ice
+++ b/src/stable/interfaces/slice/jderobot/pose3d.ice
@@ -22,7 +22,7 @@
 #ifndef POSE3D_ICE
 #define POSE3D_ICE
 
-#include <common.ice>
+#include <jderobot/common.ice>
 
 module jderobot{  
 	/**

--- a/src/stable/interfaces/slice/jderobot/pose3dencoders.ice
+++ b/src/stable/interfaces/slice/jderobot/pose3dencoders.ice
@@ -23,7 +23,7 @@
 #ifndef POSE3DENCODERS_ICE
 #define POSE3DENCODERS_ICE
 
-#include <common.ice>
+#include <jderobot/common.ice>
 
 
 module jderobot{  

--- a/src/stable/interfaces/slice/jderobot/pose3dmotors.ice
+++ b/src/stable/interfaces/slice/jderobot/pose3dmotors.ice
@@ -22,7 +22,7 @@
 #ifndef POSE3DMOTORS_ICE
 #define POSE3DMOTORS_ICE
 
-#include <common.ice>
+#include <jderobot/common.ice>
 
 module jderobot{  
 

--- a/src/stable/interfaces/slice/jderobot/ptencoders.ice
+++ b/src/stable/interfaces/slice/jderobot/ptencoders.ice
@@ -23,7 +23,7 @@
 #ifndef PTENCODERS_ICE
 #define PTENCODERS_ICE
 
-#include <common.ice>
+#include <jderobot/common.ice>
 
 
 module jderobot{  

--- a/src/stable/interfaces/slice/jderobot/ptmotors.ice
+++ b/src/stable/interfaces/slice/jderobot/ptmotors.ice
@@ -22,7 +22,7 @@
 #ifndef PTMOTORS_ICE
 #define PTMOTORS_ICE
 
-#include <common.ice>
+#include <jderobot/common.ice>
 
 module jderobot{  
 

--- a/src/stable/interfaces/slice/jderobot/remoteCloud.ice
+++ b/src/stable/interfaces/slice/jderobot/remoteCloud.ice
@@ -20,7 +20,7 @@
 #ifndef REMOTECLOUD_ICE
 #define REMOTECLOUD_ICE
 
-#include <pointcloud.ice>
+#include <jderobot/pointcloud.ice>
 
 module jderobot{  
 

--- a/src/stable/interfaces/slice/jderobot/sonars.ice
+++ b/src/stable/interfaces/slice/jderobot/sonars.ice
@@ -22,7 +22,7 @@
 #ifndef SONARS_ICE
 #define SONARS_ICE
 
-#include <common.ice>
+#include <jderobot/common.ice>
 
 
 module jderobot{  

--- a/src/stable/interfaces/slice/jderobot/varcolor.ice
+++ b/src/stable/interfaces/slice/jderobot/varcolor.ice
@@ -2,7 +2,7 @@
 #define VARCOLOR_ICE
 
 
-#include <image.ice>
+#include <jderobot/image.ice>
 
 module jderobot{  
 

--- a/src/stable/interfaces/slice/jderobot/wiimote.ice
+++ b/src/stable/interfaces/slice/jderobot/wiimote.ice
@@ -22,7 +22,7 @@
 #ifndef WIIMOTE_ICE
 #define WIIMOTE_ICE
 
-#include <common.ice>
+#include <jderobot/common.ice>
 
 module jderobot{
 


### PR DESCRIPTION
# Outsource build (2)
*Refer to #236*
## Changes:
* gazeboserver/plugins
* src/stable/interfaces

## Fixes:
* Use `${CMAKE_CURRENT_BINARY_DIR}` for all generated objects
* Use correct namespaces for .ice files
from:
```
#include <common.h>
module jderobot {
```
to:
```
#include <jderobot/common.h>
module jderobot {
```
Therefore, `include_directories()` must only include cpp root (maintain old for backward compatibility)
* Full rewrite of slice2xx to allow complex hierarchies (modules==file tree)

## Unresolved issues:
* slice2py syntax is odd. It realizes a flattened generation plus hierarchical `__init__.py`
  By the way, same problem was happening before, so it maintains exactly same format than before.
* module hierarchy is weird, (refer to java tree), interface **jointmotor** is not part of *jderobot*
```
module RoboCompJointMotor{
```
instead of
```
module jderobot{
module RoboCompJointMotor{
```

## Tested:
* cpp (compile + quadrotor)
* python (introrob_py)

## Video demo:
http://jderobot.org/store/varribas/uploads/videos/tfm-pretty-cmake.mp4