### PR TITLE
incremental releases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,8 +294,16 @@ set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA
     "${CMAKE_CURRENT_SOURCE_DIR}/scripts/cmake/postinst"
     "${CMAKE_CURRENT_SOURCE_DIR}/scripts/cmake/postrm")
 
-SET (CPACK_PACKAGE_DESCRIPTION_SUMMARY "JdeRobot is a software development suite for robotics applications.")
-SET (CPACK_PACKAGE_DESCRIPTION "JdeRobot is a software development suite for robotics applications, written in C++ language. It provides a programming environment where the robot control program is made up of a collection of several concurrent asynchronous threads named schemas. It is based on JDE cognitive architecture for autonomous robots.")
+## Patch: CPACK_PACKAGE_DESCRIPTION behavior is broken. Always use SUMMARY
+SET (CPACK_PACKAGE_DESCRIPTION_SUMMARY
+"JdeRobot is a software development suite for robotics applications.")
+SET (CPACK_PACKAGE_DESCRIPTION
+"JdeRobot is a software development suite for robotics applications, written
+in C++ language.
+It provides a programming environment where the robot control program is made
+up of a collection of several concurrent asynchronous threads named schemas.
+It is based on JDE cognitive architecture for autonomous robots.")
+SET (CPACK_PACKAGE_DESCRIPTION_SUMMARY ${CPACK_PACKAGE_DESCRIPTION})
 
 SET (CPACK_PACKAGE_CONTACT "Roberto Calvo <rocapal@gsyc.urjc.es>")
 SET (CPACK_PACKAGE_FILE_NAME "${CMAKE_PROJECT_NAME}_${CPACK_DEBIAN_PACKAGE_VERSION}_${CPACK_DEBIAN_PACKAGE_ARCHITECTURE}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,15 +294,27 @@ set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA
     "${CMAKE_CURRENT_SOURCE_DIR}/scripts/cmake/postinst"
     "${CMAKE_CURRENT_SOURCE_DIR}/scripts/cmake/postrm")
 
-## Patch: CPACK_PACKAGE_DESCRIPTION behavior is broken. Always use SUMMARY
+
+## Include Git HEAD into description (feature: traceback builds)
+execute_process(COMMAND git rev-parse HEAD
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE GIT_HEAD
+)
+string(STRIP "${GIT_HEAD}" GIT_HEAD)
+
 SET (CPACK_PACKAGE_DESCRIPTION_SUMMARY
 "JdeRobot is a software development suite for robotics applications.")
 SET (CPACK_PACKAGE_DESCRIPTION
-"JdeRobot is a software development suite for robotics applications, written
-in C++ language.
+"JdeRobot is a software development suite for robotics applications,
+written in C++ language.
 It provides a programming environment where the robot control program is made
 up of a collection of several concurrent asynchronous threads named schemas.
-It is based on JDE cognitive architecture for autonomous robots.")
+It is based on JDE cognitive architecture for autonomous robots.
+.
+Get source from https://github.com/RoboticsURJC/JdeRobot
+Package created with revision ${GIT_HEAD}")
+
+## Patch: CPACK_PACKAGE_DESCRIPTION behavior is broken. Always use SUMMARY
 SET (CPACK_PACKAGE_DESCRIPTION_SUMMARY ${CPACK_PACKAGE_DESCRIPTION})
 
 SET (CPACK_PACKAGE_CONTACT "Roberto Calvo <rocapal@gsyc.urjc.es>")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,12 +256,16 @@ SET (CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
 SET (CPACK_PACKAGING_INSTALL_PREFIX "/usr/local")
 
 
-SET (VERSION 5.3.1-rc1)
 # CPack version numbers for release tarball name.
 SET (CPACK_PACKAGE_VERSION_MAJOR 5)
 SET (CPACK_PACKAGE_VERSION_MINOR 3)
 SET (CPACK_PACKAGE_VERSION_PATCH 1)
-SET (CPACK_DEBIAN_PACKAGE_VERSION ${VERSION})
+SET (CPACK_DEBIAN_PACKAGE_VERSION ${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH})
+
+## Inject release roll up (incremental releases)
+set(PROJECT_VERSION ${CPACK_DEBIAN_PACKAGE_VERSION})
+include(scripts/incremental_releases/incremental-releases.cmake)
+set(CPACK_DEBIAN_PACKAGE_VERSION ${PROJECT_VERSION})
 
 
 SET (CPACK_DEBIAN_PACKAGE_PRIORITY "extra")
@@ -294,13 +298,13 @@ SET (CPACK_PACKAGE_DESCRIPTION_SUMMARY "JdeRobot is a software development suite
 SET (CPACK_PACKAGE_DESCRIPTION "JdeRobot is a software development suite for robotics applications, written in C++ language. It provides a programming environment where the robot control program is made up of a collection of several concurrent asynchronous threads named schemas. It is based on JDE cognitive architecture for autonomous robots.")
 
 SET (CPACK_PACKAGE_CONTACT "Roberto Calvo <rocapal@gsyc.urjc.es>")
-SET (CPACK_PACKAGE_FILE_NAME "${CMAKE_PROJECT_NAME}_${VERSION}_${CPACK_DEBIAN_PACKAGE_ARCHITECTURE}")
+SET (CPACK_PACKAGE_FILE_NAME "${CMAKE_PROJECT_NAME}_${CPACK_DEBIAN_PACKAGE_VERSION}_${CPACK_DEBIAN_PACKAGE_ARCHITECTURE}")
 
 
 ## Metapackages (at cmake time)
 include(scripts/metapackages/FindMetapackages.cmake)
 
-SET (PACKAGE_VERSION ${VERSION})
+SET (PACKAGE_VERSION ${CPACK_DEBIAN_PACKAGE_VERSION})
 #set(PACKAGE_DEPENDS "${DEPS}")
 #configure_file(${MAKE_PACKAGE_CONFIG_DIR}/jderobot-deps.info.in     ${CMAKE_BINARY_DIR}/jderobot-deps.info)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -306,13 +306,13 @@ SET (CPACK_PACKAGE_DESCRIPTION_SUMMARY
 "JdeRobot is a software development suite for robotics applications.")
 SET (CPACK_PACKAGE_DESCRIPTION
 "JdeRobot is a software development suite for robotics applications,
-written in C++ language.
-It provides a programming environment where the robot control program is made
-up of a collection of several concurrent asynchronous threads named schemas.
-It is based on JDE cognitive architecture for autonomous robots.
-.
-Get source from https://github.com/RoboticsURJC/JdeRobot
-Package created with revision ${GIT_HEAD}")
+ written in C++ language.
+ It provides a programming environment where the robot control program is made
+ up of a collection of several concurrent asynchronous threads named schemas.
+ It is based on JDE cognitive architecture for autonomous robots.
+ .
+ Get source from https://github.com/RoboticsURJC/JdeRobot
+ Package created with revision ${GIT_HEAD}")
 
 ## Patch: CPACK_PACKAGE_DESCRIPTION behavior is broken. Always use SUMMARY
 SET (CPACK_PACKAGE_DESCRIPTION_SUMMARY ${CPACK_PACKAGE_DESCRIPTION})

--- a/scripts/incremental_releases/incremental-releases.cmake
+++ b/scripts/incremental_releases/incremental-releases.cmake
@@ -1,0 +1,31 @@
+## Incremental releases
+#
+# Copyright (c) 2015
+# Author: Victor Arribas <v.arribas.urjc@gmail.com>
+# License: GPLv3 <http://www.gnu.org/licenses/gpl-3.0.html>
+#
+# Requires:
+#   * ${PROJECT_NAME}
+#   * ${PROJECT_VERSION}
+# Output:
+#   * ${PROJECT_VERSION}
+
+cmake_minimum_required(VERSION 2.8)
+
+execute_process(COMMAND "${CMAKE_CURRENT_LIST_DIR}/version-upgrader.sh" ${PROJECT_NAME} ${PROJECT_VERSION}
+	OUTPUT_VARIABLE out_version
+	RESULT_VARIABLE status
+)
+message(STATUS "Incremental Release version=${out_version}")
+
+if (status EQUAL 0)
+  set(PROJECT_VERSION ${out_version})
+else()
+  message(WARNING "incremental_releases: something went wrong.\n ${status}")
+endif()
+
+
+
+# cleanup for include() call
+unset(out_version)
+unset(status)

--- a/scripts/incremental_releases/version-upgrader.sh
+++ b/scripts/incremental_releases/version-upgrader.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+#
+# Copyright (c) 2015
+# Author: Victor Arribas <v.arribas.urjc@gmail.com>
+# License: GPLv3 <http://www.gnu.org/licenses/gpl-3.0.html>
+#
+# Usage:
+# version-upgrader.sh <package name|regex> <current version>
+
+
+# input parameters
+pkg=${1-jderobot*}
+version=${2-5.3.0}
+
+
+## Gather all possible versions from repository
+versions=$(apt-cache show $pkg 2>&1 | grep Version | awk '{print $2}')
+
+echo "$versions" | grep -q "$version"
+if [ $? -ne 0 ]
+then
+  ## Case 1: this version is not published into repository.
+  # Just add '-rc1' because is initial release
+  out_version=${version}-rc1
+else
+  ## Case 2: this version is already into repository.
+  # look for '-rcX' prefix and increment it
+  repo_last=$(echo "$versions" | grep "$version" | grep -- '-rc' | sort -nr | head -n 1)
+  number=${repo_last#${version}-rc}
+  number=$((number + 1))
+  out_version=${version}-rc${number}
+fi
+
+echo $out_version

--- a/scripts/incremental_releases/version-upgrader.sh
+++ b/scripts/incremental_releases/version-upgrader.sh
@@ -9,9 +9,13 @@
 
 
 # input parameters
-pkg=${1-jderobot*}
-version=${2-5.3.0}
+pkg=${1}
+version=${2}
 
+[ "$pkg" = "" ] && return 2
+[ "$version" = "" ] && return 2
+
+status=0
 
 ## Gather all possible versions from repository
 versions=$(apt-cache show $pkg 2>&1 | grep Version | awk '{print $2}')
@@ -25,10 +29,14 @@ then
 else
   ## Case 2: this version is already into repository.
   # look for '-rcX' prefix and increment it
-  repo_last=$(echo "$versions" | grep "$version" | grep -- '-rc' | sort -nr | head -n 1)
-  number=${repo_last#${version}-rc}
+  versions_rc_numbers=$(echo "$versions" | grep "$version" | grep -- '-rc' | sed "s,$version-rc\([0-9]+\)*,\1,")
+  number=$(echo "$versions_rc_numbers" | sort -nr | head -n 1)
+  [ "$number" = "" ] && status=1
   number=$((number + 1))
   out_version=${version}-rc${number}
 fi
 
+[ "$out_version" = "" ] && status=1
 echo -n $out_version
+
+return $status

--- a/scripts/incremental_releases/version-upgrader.sh
+++ b/scripts/incremental_releases/version-upgrader.sh
@@ -31,4 +31,4 @@ else
   out_version=${version}-rc${number}
 fi
 
-echo $out_version
+echo -n $out_version


### PR DESCRIPTION
*Related to #268*

## Test roadmap
Minimal Test:
  1. Simple `cmake ..` to ensure it is working
  2. Check `.deb` generated by metapackages
  3. `make package` and check it

A. Real case usage I:
  1. cmake or make package and push .deb to repo
  2. repeat x2 and see incremental rc

B. Real case usage II:
  1. Change major/minor/patch
  2. cmake and check suffix == `-rc1`

C. Test script bounds I:
  1. do by hand a x.y.z-rc9 and rc10
  2. push both into repo
  3. cmake to see if versioning number is respected
    - wrong result: -rc10
    - success result: -rc11

D. Test script bounds II:
  1. Change manually `CPACK_DEBIAN_PACKAGE_VERSION`
  2. See what happens. Expected:
    - warning but ok
    - version is unchanged
