### PR TITLE
Outsource build (3): last components

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,12 +184,12 @@ ENDFOREACH(currentSourceFile)
 list_subdirectories2( LIST_COMPONENTS ${CMAKE_CURRENT_SOURCE_DIR}/src/stable/components/ 1)
 
 FOREACH (currentBin ${LIST_COMPONENTS})
-    #SET(EXIST EXIST-NOTFOUND)
-    find_file(EXIST NAMES ${currentBin} PATHS ${CMAKE_CURRENT_SOURCE_DIR}/src/components/${currentBin})
-    #IF (EXIST)
-    INSTALL (PROGRAMS ${CMAKE_CURRENT_SOURCE_DIR}/src/stable/components/${currentBin}/${currentBin} DESTINATION /usr/local/bin OPTIONAL COMPONENT core)
-    #ENDIF(EXIST)
-    #MESSAGE("${EXIST}")
+    if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/stable/components/${currentBin}/${currentBin})
+        INSTALL (PROGRAMS ${CMAKE_CURRENT_SOURCE_DIR}/src/stable/components/${currentBin}/${currentBin} DESTINATION /usr/local/bin OPTIONAL COMPONENT core)
+    endif()
+    if (EXISTS ${CMAKE_CURRENT_BINARY_DIR}/src/stable/components/${currentBin}/${currentBin})
+        INSTALL (PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/src/stable/components/${currentBin}/${currentBin} DESTINATION /usr/local/bin OPTIONAL COMPONENT core)
+    endif()
 ENDFOREACH(currentBin)
 
 # Install interfaces headers

--- a/src/stable/components/basic_server/CMakeLists.txt
+++ b/src/stable/components/basic_server/CMakeLists.txt
@@ -1,7 +1,9 @@
 
 
 
-execute_process(COMMAND slice2cpp ${CMAKE_CURRENT_LIST_DIR}/myInterface.ice WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR})
+execute_process(COMMAND slice2cpp myInterface.ice --output-dir ${CMAKE_CURRENT_BINARY_DIR}
+	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
 
 SET( SOURCE_FILES  basic_server.cpp myInterface.cpp)
 
@@ -9,7 +11,7 @@ SET( SOURCE_FILES  basic_server.cpp myInterface.cpp)
 include_directories(
     ${INTERFACES_CPP_DIR}
     ${LIBS_DIR}
-    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 add_executable (basic_server  ${SOURCE_FILES})

--- a/src/stable/components/followBall/CMakeLists.txt
+++ b/src/stable/components/followBall/CMakeLists.txt
@@ -54,11 +54,9 @@ else()
         ${OpenCV_INCLUDE_DIRS}
     )
 
-    set(EXECUTABLE_OUTPUT_PATH ${CMAKE_CURRENT_SOURCE_DIR})
+    add_executable (followBall ${SOURCE_FILES_FOLLOWBALL})
 
-    add_executable (followball ${SOURCE_FILES_FOLLOWBALL})
-
-    TARGET_LINK_LIBRARIES ( followball
+    TARGET_LINK_LIBRARIES ( followBall
         JderobotInterfaces
         jderobotutil
         colorspacesmm


### PR DESCRIPTION
# Outsource build (3): last components

* all components should now respect outsource build
  * followBall
  * basic_server
* improve cmake rule that install executables at /usr/local/bin
  * this rule is NOT correct due it install files that could be blacklisted, but change it is not trivial.
