### PR TITLE
Partial solution to #263, applied to navigatorCamera

### DIFF
--- a/src/stable/components/navigatorCamera/CMakeLists.txt
+++ b/src/stable/components/navigatorCamera/CMakeLists.txt
@@ -16,6 +16,7 @@ include_directories(
 	${libglademm_INCLUDE_DIRS}
 	${gtkglextmm_INCLUDE_DIRS}
 	${ZLIB_INCLUDE_DIRS}
+        ${easyiceconfig_INCLUDE_DIRS}
 )
 
 add_executable (navigatorCamera  ${SOURCE_FILES})
@@ -31,4 +32,5 @@ TARGET_LINK_LIBRARIES(navigatorCamera
 	parallelIce
 	${ZeroCIce_LIBRARIES}
 	${ZLIB_LIBRARIES}
+        ${easyiceconfig_LIBRARY_DIRS}
 )

--- a/src/stable/components/navigatorCamera/gui.cpp
+++ b/src/stable/components/navigatorCamera/gui.cpp
@@ -1,16 +1,29 @@
 #include "gui.h"
 
+#include "easyiceconfig/loader.hpp"
+#include "easyiceconfig/hardcoredlocations.h"
+
 namespace navigatorCamera {
 
-	Gui::Gui(Sharer *sharer,const std::string& gladeFile) : gtkmain(0, 0)
+	Gui::Gui(Sharer *sharer) : gtkmain(0, 0)
 	{
 
 		this->sharer = sharer;
 
 		std::cout << "Loading glade." << std::endl;
 
-		const std::string gladepath = std::string(GLADE_DIR) + gladeFile;
-		refXml = Gnome::Glade::Xml::create(gladepath);
+		std::string gladeFile;
+
+		//const std::string gladepath = std::string(GLADE_DIR) + gladeFile;
+		for (std::string path : std::split(HARDCORED_LOCATIONS, ":")){
+			if (path.empty()) continue;
+			std::string filepath(path+"/navigatorCamera.glade");
+			if (std::fileexists(filepath)){
+				gladeFile = filepath;
+				break;
+			}
+		}		
+		refXml = Gnome::Glade::Xml::create(gladeFile);
 
 		refXml->get_widget("showWindow", showWindow);
 		refXml->get_widget("RGB", RGB);

--- a/src/stable/components/navigatorCamera/gui.h
+++ b/src/stable/components/navigatorCamera/gui.h
@@ -10,7 +10,6 @@
 
 #define pi 3.14159265358979
 
-
 namespace navigatorCamera {
 
 	class Gui {
@@ -21,7 +20,7 @@ namespace navigatorCamera {
 		 * @param sharer	Sharer instance associated to this GUI.
 		 * @param gladeFile	Glade XML file path.
 		 */
-		Gui(Sharer *sharer, const std::string& gladeFile);
+		Gui(Sharer *sharer);
 
 		/// Default destructor.
 		virtual ~Gui();

--- a/src/stable/components/navigatorCamera/navigatorCamera.cpp
+++ b/src/stable/components/navigatorCamera/navigatorCamera.cpp
@@ -14,7 +14,6 @@
 // Global Memory
 navigatorCamera::Sharer *sharer;
 
-
 inline long cycleWait(long cycle, long diff)
 {
 	diff = (diff > cycle)?cycle:diff;
@@ -27,15 +26,14 @@ inline long cycleWait(long cycle, long diff)
 
 // ################################## Threads ##################################
 
-void *showGui(void* gladeFile_ptr)
+void *showGui(void*)
 {
 	struct timeval a, b;
 	long totala, totalb;
 	long diff;
 	navigatorCamera::Gui *gui;
-	std::string gladeFile = *(std::string *)gladeFile_ptr;
 
-	gui = new navigatorCamera::Gui(sharer, gladeFile);
+	gui = new navigatorCamera::Gui(sharer);
 
 	while ( gui->isVisible() )
 	{
@@ -162,7 +160,12 @@ int main(int argc, char** argv)
 		ic = Ice::initialize(argc,argv);
 		Ice::PropertiesPtr prop = ic->getProperties();
 
-		gladeFile = prop->getPropertyWithDefault(prefix + ".gladeFile", "./" + prefix + ".glade");
+		//gladeFile = prop->getPropertyWithDefault(prefix + ".gladeFile", "./" + prefix + ".glade");
+   
+
+   
+
+
 
 		guiActivated = prop->getPropertyAsIntWithDefault(prefix + ".guiActivated",1);
 		controlActivated = prop->getPropertyAsIntWithDefault(prefix + ".controlActivated",0);
@@ -197,7 +200,7 @@ int main(int argc, char** argv)
 		sharer->setGuiVisible(guiActivated);
 		sharer->setControlActive(controlActivated);
 		if ( guiActivated )
-			pthread_create(&thr_gui, NULL, &showGui, static_cast<void *>(&gladeFile));
+			pthread_create(&thr_gui, NULL, &showGui, NULL);
 
 		pthread_create(&thr_camera, NULL, &updateCamera, static_cast<void *>(camRGB));
 		

--- a/src/stable/libs/easyiceconfig_cpp/include/easyiceconfig/hardcoredlocations.h
+++ b/src/stable/libs/easyiceconfig_cpp/include/easyiceconfig/hardcoredlocations.h
@@ -23,6 +23,7 @@
 
 const char* HARDCORED_LOCATIONS =
 "/usr/local/share/jderobot/conf\
+:/usr/local/share/jderobot/glade\
 :/usr/local/share/jderobot/gazebo/plugins/car\
 :/usr/local/share/jderobot/gazebo/plugins/flyingKinect\
 :/usr/local/share/jderobot/gazebo/plugins/kinect\


### PR DESCRIPTION
Taking advantage of [hardcoredlocations](https://github.com/RoboticsURJC/JdeRobot/blob/master/src/stable/libs/easyiceconfig_cpp/include/easyiceconfig/hardcoredlocations.h) from easyiceconfig, I've implemented a "simple" solution to make possible the execution of glade dependent components from everywhere in the system. This method, with easyiceconfig, would make us able to run components from everywhere without caring where we launch them.
Ping to @varhub to revise this solution, and give me some hints to improve the implementation.