### PR TITLE
build aliases (2): major improvements and fixes

### DIFF
--- a/buildpresets.cmake
+++ b/buildpresets.cmake
@@ -32,7 +32,7 @@ function (build_component component value)
 	if (NOT DEFINED build_${component})
 		set(build_${component} ${value} CACHE BOOL "Build flag for JdeRobot component: ${component} (defined by builtpresets)")
 	elseif (NOT build_${component} EQUAL ${value})
-		override_cache(build_${component} OFF FORCE)
+		override_cache(build_${component} ${value} FORCE)
 	endif()
 endfunction()
 

--- a/buildpresets.cmake
+++ b/buildpresets.cmake
@@ -141,7 +141,23 @@ if (build_core)
 	set(build-default OFF)
 
 	build_component(msgs ON "ONLY_ON")
-	# libs are included by default at now
+
+	# libs
+	build_component(depthLib ON)
+	build_component(easyiceconfig_cpp ON)
+	build_component(easyiceconfig_py ON)
+	build_component(fuzzylib ON)
+	build_component(geometry ON)
+	build_component(jderobotHandlers ON)
+	build_component(jderobotViewer ON)
+	build_component(jderobotutil ON)
+	build_component(log ON)
+	build_component(ns ON)
+	build_component(parallelIce ON)
+	build_component(pioneer ON)
+	build_component(progeo ON)
+	build_component(visionlib ON)
+	build_component(xmlParser ON)
 endif()
 
 if (build_msgs)
@@ -151,7 +167,6 @@ if (build_msgs)
 	build_component(interfaces_cpp ON)
 	build_component(interfaces_java ON)
 	build_component(interfaces_python ON)
-	# todo: remove libs from this build flavor
 endif()
 
 #message(SEND_ERROR "PROJECT_NAME: ${PROJECT_NAME}")


### PR DESCRIPTION
# build aliases (2): major improvements and fixes
*Completeness for #264*

## Changeset
  * **build_purge**, the alternative to delete cache
  * better cache handling
  * rewrite project name no longer requires remove cache
  * fix build_all flag
  * more explaining comments

## New usage
1. cmake -Dbuild_x=ON -Dbuild_y=ON [...] --> initial cmake (creates cache)
2. cmake -Dbuild_z=ON [...] --> configure it a little bit more
3. make --> builds x,y,z

If you want to build another think, you MUST delete CMakeCache, but no longer with build_purge:
4. cmake -Dbuild_purge=ON --> disable every build_x; even stronger that remove cache
5. cmake -Dbuild_a=ON -Dbuild_b=ON [...] --> like initial cmake call
6. make --> builds a,b