### PR TITLE
metapackages: better name and version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,11 +258,6 @@ SET (CPACK_PACKAGE_VERSION_MINOR 3)
 SET (CPACK_PACKAGE_VERSION_PATCH 1)
 SET (CPACK_DEBIAN_PACKAGE_VERSION ${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH})
 
-## Inject release roll up (incremental releases)
-set(PROJECT_VERSION ${CPACK_DEBIAN_PACKAGE_VERSION})
-include(scripts/incremental_releases/incremental-releases.cmake)
-set(CPACK_DEBIAN_PACKAGE_VERSION ${PROJECT_VERSION})
-
 
 SET (CPACK_DEBIAN_PACKAGE_PRIORITY "extra")
 SET (CPACK_DEBIAN_PACKAGE_SECTION "net")
@@ -321,16 +316,24 @@ SET (CPACK_PACKAGE_FILE_NAME "${CMAKE_PROJECT_NAME}_${CPACK_DEBIAN_PACKAGE_VERSI
 include(scripts/metapackages/FindMetapackages.cmake)
 
 SET (PACKAGE_VERSION ${CPACK_DEBIAN_PACKAGE_VERSION})
-#set(PACKAGE_DEPENDS "${DEPS}")
-#configure_file(${MAKE_PACKAGE_CONFIG_DIR}/jderobot-deps.info.in     ${CMAKE_BINARY_DIR}/jderobot-deps.info)
+set(PACKAGE_DEPENDS "${DEPS}")
+configure_file(${MAKE_PACKAGE_CONFIG_DIR}/jderobot-deps.info.in     ${CMAKE_BINARY_DIR}/jderobot-deps_${PACKAGE_VERSION}_all.info)
 
 set(PACKAGE_DEPENDS "${DEPS_DEV}")
-configure_file(${MAKE_PACKAGE_CONFIG_DIR}/jderobot-deps-dev.info.in ${CMAKE_BINARY_DIR}/jderobot-deps-dev.info)
+configure_file(${MAKE_PACKAGE_CONFIG_DIR}/jderobot-deps-dev.info.in ${CMAKE_BINARY_DIR}/jderobot-deps-dev_${PACKAGE_VERSION}_all.info)
 
 execute_process(
     COMMAND ${MAKE_PACKAGE_EXECUTABLE}
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 )
+
+
+## Inject release roll up (incremental releases)
+# this step should be only for jderobot package
+set(PROJECT_VERSION ${CPACK_DEBIAN_PACKAGE_VERSION})
+include(scripts/incremental_releases/incremental-releases.cmake)
+set(CPACK_DEBIAN_PACKAGE_VERSION ${PROJECT_VERSION})
+
 
 #SET (CPACK_COMPONENTS_ALL Libraries ApplicationData)
 include (CPack Documentation)

--- a/scripts/metapackages/jderobot-deps-dev.info.in
+++ b/scripts/metapackages/jderobot-deps-dev.info.in
@@ -1,12 +1,17 @@
 Package: jderobot-deps-dev
 Version: ${PACKAGE_VERSION}
 Architecture: all
+Provides: jderobot-deps-dev
+Conflicts: jderobot-deps-dev
+Replaces: jderobot-deps-dev
 Section: net
 Priority: extra
 Size: 0
 Installed-Size: 0
 Depends: ${PACKAGE_DEPENDS}
 Maintainer: Francisco Perez <f.perez475@gmail.com>
+Private-Original-Maintainer: Victor Arribas <v.arribas.urjc@gmail.com>
+Homepage: http://jderobot.org
 Description: Metapackage that gathers all library headers required to compile JdeRobot framework.
  Jderobot is a software development suite for robotics applications.
  Get it from https://github.com/RoboticsURJC/JdeRobot

--- a/scripts/metapackages/jderobot-deps.info.in
+++ b/scripts/metapackages/jderobot-deps.info.in
@@ -1,12 +1,16 @@
 Package: jderobot-deps
 Version: ${PACKAGE_VERSION}
 Architecture: all
+Provides: jderobot-deps
+Conflicts: jderobot-deps
+Replaces: jderobot-deps
 Priority: extra
 Section: net
 Size: 0
 Installed-Size: 0
 Depends: ${PACKAGE_DEPENDS}
 Maintainer: Francisco Perez <f.perez475@gmail.com>
+Private-Original-Maintainer: Victor Arribas <v.arribas.urjc@gmail.com>
+Homepage: http://jderobot.org
 Description: Metapackage that gathers all libraries required by JdeRobot framework.
  Jderobot is a software development suite for robotics applications.
-


### PR DESCRIPTION
jderobot-deps-dev must not adquire *-rcX* suffix.
If deps changes, then version should be roll up to catch and notify this change.

changeset include some improvements at debian/control files.
See commits for more info.

*tags: enhance, aptitude*