### PR TITLE
[issue #337] Absolute interfaces for: kobukiViewer, turtlebot motors.

### DIFF
--- a/src/stable/components/gazeboserver/plugins/pioneer/motors.cc
+++ b/src/stable/components/gazeboserver/plugins/pioneer/motors.cc
@@ -113,9 +113,9 @@ namespace gazebo {
 
         pthread_mutex_lock(&mutex);
 
-        vr = robotMotors.v/100;
+        vr = robotMotors.v;
 
-        va = robotMotors.w/10;
+        va = robotMotors.w;
 
         pthread_mutex_unlock(&mutex);
 

--- a/src/stable/components/gazeboserver/plugins/turtlebot/motors.cc
+++ b/src/stable/components/gazeboserver/plugins/turtlebot/motors.cc
@@ -112,10 +112,10 @@ namespace gazebo {
 
         pthread_mutex_lock(&mutex);
 
-        vr = robotMotors.v/100;
+        vr = robotMotors.v;
 
-        va = robotMotors.w/10;
-
+        va = robotMotors.w;
+	
         pthread_mutex_unlock(&mutex);
 
 

--- a/src/stable/components/kobukiViewer/gui/gui.cpp
+++ b/src/stable/components/kobukiViewer/gui/gui.cpp
@@ -45,7 +45,7 @@ GUI::GUI(Robot* robot, StateGUI *state)
 
     connect(buttonStopRobot, SIGNAL(clicked()),this, SLOT(on_buttonStopRobot_clicked()) );
 
-    connect(canvasVW, SIGNAL(VW_changed(int,int)), this, SLOT(on_update_canvas_recieved(int, int)));
+    connect(canvasVW, SIGNAL(VW_changed(float,float)), this, SLOT(on_update_canvas_recieved(float, float)));
 
     connect(check3DWorld, SIGNAL(stateChanged(int)), this, SLOT(on_checks_changed()));
     connect(checkLaser, SIGNAL(stateChanged(int)), this, SLOT(on_checks_changed()));
@@ -64,8 +64,9 @@ void GUI::on_checks_changed()
     laserWidget->setVisible(checkLaser->isChecked());
 }
 
-void GUI::on_update_canvas_recieved(int v, int w)
+void GUI::on_update_canvas_recieved(float v, float w)
 {
+
     this->robot->getActuators()->setMotorV((float)v);
     this->robot->getActuators()->setMotorW((float)w);
 }

--- a/src/stable/components/kobukiViewer/gui/gui.h
+++ b/src/stable/components/kobukiViewer/gui/gui.h
@@ -45,7 +45,7 @@ public slots:
     void on_updateGUI_recieved();
     void on_buttonStopRobot_clicked();
 
-    void on_update_canvas_recieved(int v, int w);
+    void on_update_canvas_recieved(float v, float w);
     void on_checks_changed();
 
 };

--- a/src/stable/components/kobukiViewer/gui/widget/controlvw.cpp
+++ b/src/stable/components/kobukiViewer/gui/widget/controlvw.cpp
@@ -21,6 +21,10 @@ controlVW::controlVW(QWidget *parent) :
     setMinimumSize(400, 400);
     qimage.load(":/images/pelota.png");
 
+	setMouseTracking(true);
+	this->v = 0;
+	this->w = 0;
+
 }
 
 void controlVW::Stop()
@@ -41,9 +45,14 @@ void controlVW::mouseMoveEvent ( QMouseEvent * event )
 
         line = QPointF(x, y);
 
+		//Show tooltip with the current v and w
+		QString aa = "v: " + QString::number(v) + " , w: " + QString::number(w);
+		QToolTip::showText(QPoint(QCursor::pos()), aa);
+
         repaint();
 
     }
+
 }
 
 void controlVW::paintEvent(QPaintEvent *)
@@ -87,12 +96,18 @@ void controlVW::paintEvent(QPaintEvent *)
    float k = 0.01;
    float p = 0;
 
-   float v_normalized = 40 * (k * line.y() + p)*(-1);
-   float w_normalized = 20 * (k * line.x() + p)*(-1);
+   //float v_normalized = 40 * (k * line.y() + p)*(-1);
+   //float w_normalized = 20 * (k * line.x() + p)*(-1);
+
+	float v_normalized = (line.y()/40.0)*(-1);
+   	float w_normalized = (line.x()/400.0)*(-1);
+
+	this->v = v_normalized;
+	this->w = w_normalized;
 
 //   std::cout << "v_normalized: " << v_normalized << " w_normalized: " << w_normalized << std::endl;
 
-   emit VW_changed((int)v_normalized, (int)w_normalized);
+   emit VW_changed(v_normalized, w_normalized);
 
    painter.drawImage(line.x()-qimage.width()/2, line.y()-qimage.height()/2, qimage);
 

--- a/src/stable/components/kobukiViewer/gui/widget/controlvw.h
+++ b/src/stable/components/kobukiViewer/gui/widget/controlvw.h
@@ -4,6 +4,7 @@
 #include <QtGui>
 
 #include <iostream>
+#include <string>
 
 class controlVW : public QWidget
 {
@@ -17,12 +18,14 @@ private:
     QPointF line;
     QImage qimage;
 
+	float v, w;
+
 protected:
     void paintEvent(QPaintEvent *);
     void mouseMoveEvent ( QMouseEvent * event );
 
 signals:
-    void VW_changed(int, int);
+    void VW_changed(float, float);
 
 public slots:
     


### PR DESCRIPTION
By now the configuration of the maximum linear and angular velocity offered by kobukiViewer are:

 * **linear: 5 m/s** (18 km/h or 11,18 mph)
 * **angular: 0.5 rad/s** (28,64 deg/s)

Drivers to change: 
  * [x] turtlebot (simulated)
  * [x] pioneer (simulated)
  * [x] Formula1 (simulated)
  * [x] kobuki (real) 

Clients to change:
  * [x] kobukiViewer