### PR TITLE
[Issue #435] Quick-fixes CMAKE_CXX_FLAGS resetting. Removes direct c++0x asignment.

### DIFF
--- a/src/stable/components/followBall/CMakeLists.txt
+++ b/src/stable/components/followBall/CMakeLists.txt
@@ -42,7 +42,7 @@ if (COMPILEFORNAO)
 else()
     SET( SOURCE_FILES_FOLLOWBALL viewer.cpp sensors.cpp control.cpp handler.cpp main.cpp )
 
-    SET( CMAKE_CXX_FLAGS "-Wno-deprecated" ) # Opciones para el compilador
+    SET( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated" ) # Opciones para el compilador
 
     include_directories (
         ${INTERFACES_CPP_DIR}

--- a/src/stable/components/recorder/CMakeLists.txt
+++ b/src/stable/components/recorder/CMakeLists.txt
@@ -2,7 +2,7 @@ SET(SOURCE_FILES recorder.cpp recordergui.cpp poolWriteImages.cpp poolWritePose3
 
 add_definitions(-DGLADE_DIR="${gladedir}")
 
-set( CMAKE_CXX_FLAGS "-Wno-deprecated" ) # Opciones para el compilador
+set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated" ) # Opciones para el compilador
 
 include_directories(
     ${INTERFACES_CPP_DIR}

--- a/src/stable/components/remoteConfiguration/CMakeLists.txt
+++ b/src/stable/components/remoteConfiguration/CMakeLists.txt
@@ -6,7 +6,7 @@ IF (libxmlpp_INCLUDE_DIRS)
 
 	add_definitions(-DGLADE_DIR="${gladedir}")
 
-	set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated" ) # Opciones para el compilador-lgsl -lgslcblas -lGL -lGLU -lglut -lgazebo
+	set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated" ) # Opciones para el compilador
 
 	include_directories(
 		${INTERFACES_CPP_DIR}

--- a/src/stable/components/remoteConfiguration/CMakeLists.txt
+++ b/src/stable/components/remoteConfiguration/CMakeLists.txt
@@ -6,7 +6,7 @@ IF (libxmlpp_INCLUDE_DIRS)
 
 	add_definitions(-DGLADE_DIR="${gladedir}")
 
-	set( CMAKE_CXX_FLAGS "-Wno-deprecated" ) # Opciones para el compilador-lgsl -lgslcblas -lGL -lGLU -lglut -lgazebo
+	set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated" ) # Opciones para el compilador-lgsl -lgslcblas -lGL -lGLU -lglut -lgazebo
 
 	include_directories(
 		${INTERFACES_CPP_DIR}

--- a/src/stable/components/replayer/CMakeLists.txt
+++ b/src/stable/components/replayer/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 add_definitions(-DGLADE_DIR="${gladedir}")
 
-set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated" ) # Opciones para el compilador-lgsl -lgslcblas -lGL -lGLU -lglut -lgazebo
+set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated" ) # Opciones para el compilador
 
 include_directories(
     ${INTERFACES_CPP_DIR}

--- a/src/stable/components/replayer/CMakeLists.txt
+++ b/src/stable/components/replayer/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 add_definitions(-DGLADE_DIR="${gladedir}")
 
-set( CMAKE_CXX_FLAGS "-Wno-deprecated" ) # Opciones para el compilador-lgsl -lgslcblas -lGL -lGLU -lglut -lgazebo
+set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated" ) # Opciones para el compilador-lgsl -lgslcblas -lGL -lGLU -lglut -lgazebo
 
 include_directories(
     ${INTERFACES_CPP_DIR}

--- a/src/stable/components/teleoperator/CMakeLists.txt
+++ b/src/stable/components/teleoperator/CMakeLists.txt
@@ -13,7 +13,7 @@ link_directories(
 	${easyiceconfig_LIBRARY_DIRS}
 )
 
-set( CMAKE_CXX_FLAGS "-Wno-deprecated" ) # Opciones para el compilador
+set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated" ) # Opciones para el compilador
 
 add_executable (teleoperatorPC  ${SOURCE_FILES})
 

--- a/src/stable/drivers/gazeboserver/plugins/flyingKinect/CMakeLists.txt
+++ b/src/stable/drivers/gazeboserver/plugins/flyingKinect/CMakeLists.txt
@@ -13,7 +13,7 @@ link_directories(
 	${GAZEBO_LIBRARY_DIRS} 
 	)
 
-set( CMAKE_CXX_FLAGS "-Wall -lpcl_filters" ) # Opciones para el compilador
+set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -lpcl_filters" ) # Opciones para el compilador
 
 add_library(kinect SHARED kinect.cc sharer.cc)
 

--- a/src/stable/drivers/gazeboserver/plugins/flyingKinect2/CMakeLists.txt
+++ b/src/stable/drivers/gazeboserver/plugins/flyingKinect2/CMakeLists.txt
@@ -31,7 +31,7 @@ link_directories(
 
 
 ## Project
-set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=c++0x" ) # Opciones para el compilador
+set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall" ) # Opciones para el compilador
 
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include")
 

--- a/src/stable/drivers/gazeboserver/plugins/kinect/CMakeLists.txt
+++ b/src/stable/drivers/gazeboserver/plugins/kinect/CMakeLists.txt
@@ -13,7 +13,7 @@ link_directories(
 	${GAZEBO_LIBRARY_DIRS} 
 	)
 
-set( CMAKE_CXX_FLAGS "-Wall -lpcl_filters" ) # Opciones para el compilador
+set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -lpcl_filters" ) # Opciones para el compilador
 
 add_library(kinectPlugin SHARED kinectPlugin.cc)
 

--- a/src/stable/tools/cameraview/CMakeLists.txt
+++ b/src/stable/tools/cameraview/CMakeLists.txt
@@ -2,7 +2,7 @@ SET( SOURCE_FILES cameraview.cpp viewer.cpp)
 
 add_definitions(-DGLADE_DIR="${gladedir}")
 
-set( CMAKE_CXX_FLAGS "-Wno-deprecated" )
+set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated" )
 
 include_directories(
     ${INTERFACES_CPP_DIR}

--- a/src/stable/tools/naoviewer/CMakeLists.txt
+++ b/src/stable/tools/naoviewer/CMakeLists.txt
@@ -2,7 +2,7 @@ IF (goocanvasmm_INCLUDE_DIRS)
 
 SET( SOURCE_FILES_NAOOPERATOR sensors.cpp control.cpp naooperator.cpp displayer.cpp main.cpp )
 
-SET( CMAKE_CXX_FLAGS "-Wno-deprecated" ) # Opciones para el compilador
+SET( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated" ) # Opciones para el compilador
 
 include_directories (
     ${INTERFACES_CPP_DIR}

--- a/src/stable/tools/recorder2/CMakeLists.txt
+++ b/src/stable/tools/recorder2/CMakeLists.txt
@@ -2,7 +2,7 @@ SET(SOURCE_FILES recordergui.cpp poolWriteImages.cpp poolWritePose3dEncoders.cpp
 
 add_definitions(-DGLADE_DIR="${gladedir}")
 
-set( CMAKE_CXX_FLAGS "-Wno-deprecated" ) # Opciones para el compilador-lgsl -lgslcblas -lGL -lGLU -lglut -lgazebo
+set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated" ) # Opciones para el compilador-lgsl -lgslcblas -lGL -lGLU -lglut -lgazebo
 
 include_directories(
     ${INTERFACES_CPP_DIR}

--- a/src/stable/tools/recorder2/CMakeLists.txt
+++ b/src/stable/tools/recorder2/CMakeLists.txt
@@ -2,7 +2,7 @@ SET(SOURCE_FILES recordergui.cpp poolWriteImages.cpp poolWritePose3dEncoders.cpp
 
 add_definitions(-DGLADE_DIR="${gladedir}")
 
-set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated" ) # Opciones para el compilador-lgsl -lgslcblas -lGL -lGLU -lglut -lgazebo
+set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated" ) # Opciones para el compilador
 
 include_directories(
     ${INTERFACES_CPP_DIR}

--- a/src/stable/tools/replayController/CMakeLists.txt
+++ b/src/stable/tools/replayController/CMakeLists.txt
@@ -6,7 +6,7 @@ SET( SOURCE_FILES replayController.cpp replayControllerGui.cpp)
 
 add_definitions(-DGLADE_DIR="${gladedir}")
 
-set( CMAKE_CXX_FLAGS "-Wno-deprecated" ) # Opciones para el compilador
+set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated" ) # Opciones para el compilador
 
 include_directories(
     ${INTERFACES_CPP_DIR}

--- a/src/stable/tools/replayer2/CMakeLists.txt
+++ b/src/stable/tools/replayer2/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 add_definitions(-DGLADE_DIR="${gladedir}")
 
-set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated" ) # Opciones para el compilador-lgsl -lgslcblas -lGL -lGLU -lglut -lgazebo
+set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated" ) # Opciones para el compilador
 
 include_directories(
     ${INTERFACES_CPP_DIR}

--- a/src/stable/tools/replayer2/CMakeLists.txt
+++ b/src/stable/tools/replayer2/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 add_definitions(-DGLADE_DIR="${gladedir}")
 
-set( CMAKE_CXX_FLAGS "-Wno-deprecated" ) # Opciones para el compilador-lgsl -lgslcblas -lGL -lGLU -lglut -lgazebo
+set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated" ) # Opciones para el compilador-lgsl -lgslcblas -lGL -lGLU -lglut -lgazebo
 
 include_directories(
     ${INTERFACES_CPP_DIR}

--- a/src/stable/tools/rgbdViewer/CMakeLists.txt
+++ b/src/stable/tools/rgbdViewer/CMakeLists.txt
@@ -1,6 +1,6 @@
 SET(SOURCE_FILES rgbdViewer.cpp drawarea.cpp rgbdViewergui.cpp myprogeo.cpp)
 
-set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated" ) # Opciones para el compilador-lgsl -lgslcblas -lGL -lGLU -lglut -lgazebo
+set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated" ) # Opciones para el compilador
 
 include_directories(
     ${INTERFACES_CPP_DIR}

--- a/src/stable/tools/rgbdViewer/CMakeLists.txt
+++ b/src/stable/tools/rgbdViewer/CMakeLists.txt
@@ -1,6 +1,6 @@
 SET(SOURCE_FILES rgbdViewer.cpp drawarea.cpp rgbdViewergui.cpp myprogeo.cpp)
 
-set( CMAKE_CXX_FLAGS "-Wno-deprecated" ) # Opciones para el compilador-lgsl -lgslcblas -lGL -lGLU -lglut -lgazebo
+set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated" ) # Opciones para el compilador-lgsl -lgslcblas -lGL -lGLU -lglut -lgazebo
 
 include_directories(
     ${INTERFACES_CPP_DIR}


### PR DESCRIPTION
[Issue #435]
This solves - at least partially - the CMAKE_CXX_FLAGS by prepending the current value to the new.
Also removes a "-std=c++0x", which conflicts with compilers that use only "-std=c++11" or can't use both at the same time; this flag is managed by another CMakeLists.txt anyway.