### PR TITLE
[Issue #452] Fixes CMake checks and output for OpenGL and GLUT.

### DIFF
--- a/Deps/opengl/CMakeLists.txt
+++ b/Deps/opengl/CMakeLists.txt
@@ -1,16 +1,18 @@
 include(FindPkgConfig)
 find_package(GLUT)
 find_package(OpenGL REQUIRED)
-include_directories(${GLUT_INCLUDE_DIRS} ${OPENGL_INCLUDE_DIRS})
 
-link_directories(${OPENGL_LIBRARIES} ${GLUT_LIBRARY} )
+IF (NOT GLUT_LIBRARIES MATCHES ".*NOTFOUND.*" AND
+    NOT OPENGL_LIBRARIES MATCHES ".*NOTFOUND.*") 
+        MESSAGE("OpenGL libraries found at ${GLUT_LIBRARIES}")
 
+        include_directories(${GLUT_INCLUDE_DIRS} ${OPENGL_INCLUDE_DIRS})
+        link_directories(${OPENGL_LIBRARIES} ${GLUT_LIBRARIES} )
 
-IF (GLUT_LIBRARIES) 
-	MESSAGE("OpenGL libraries found at ${GLUT_LIBRARY}")
-	list(APPEND DEPS freeglut3 libglu1-mesa)
-	list(APPEND DEPS_DEV freeglut3-dev libglu1-mesa-dev)
+        list(APPEND DEPS freeglut3 libglu1-mesa)
+        list(APPEND DEPS_DEV freeglut3-dev libglu1-mesa-dev)
 ELSE()
-	MESSAGE ("*** OpenGL not found")
+        MESSAGE ("*** OpenGL not found")
 ENDIF()
+
 


### PR DESCRIPTION
Should fix the issue #452 according to the suggestion of checking first the list for `NOTFOUND` before trying to link the paths and making the finding check user output  consistent.

Also corrects the usage of the deprecated variables.