### PR TITLE
[Issue #463] Includes new paths to the install generation step in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,6 +175,8 @@ ENDFOREACH(currentSourceFile)
 
 # Install Executables
 list_subdirectories2( LIST_COMPONENTS ${CMAKE_CURRENT_SOURCE_DIR}/src/stable/components/ 1)
+list_subdirectories2( LIST_DRIVERS ${CMAKE_CURRENT_SOURCE_DIR}/src/stable/drivers/ 1)
+list_subdirectories2( LIST_TOOLS ${CMAKE_CURRENT_SOURCE_DIR}/src/stable/tools/ 1)
 
 FOREACH (currentBin ${LIST_COMPONENTS})
     if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/stable/components/${currentBin}/${currentBin})
@@ -184,6 +186,26 @@ FOREACH (currentBin ${LIST_COMPONENTS})
         INSTALL (PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/src/stable/components/${currentBin}/${currentBin} DESTINATION /usr/local/bin OPTIONAL COMPONENT core)
     endif()
 ENDFOREACH(currentBin)
+
+FOREACH (currentBin ${LIST_DRIVERS})
+    if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/stable/drivers/${currentBin}/${currentBin})
+        INSTALL (PROGRAMS ${CMAKE_CURRENT_SOURCE_DIR}/src/stable/drivers/${currentBin}/${currentBin} DESTINATION /usr/local/bin OPTIONAL COMPONENT core)
+    endif()
+    if (EXISTS ${CMAKE_CURRENT_BINARY_DIR}/src/stable/drivers/${currentBin}/${currentBin})
+        INSTALL (PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/src/stable/drivers/${currentBin}/${currentBin} DESTINATION /usr/local/bin OPTIONAL COMPONENT core)
+    endif()
+ENDFOREACH(currentBin)
+
+FOREACH (currentBin ${LIST_TOOLS})
+    if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/src/stable/tools/${currentBin}/${currentBin})
+        INSTALL (PROGRAMS ${CMAKE_CURRENT_SOURCE_DIR}/src/stable/toolss/${currentBin}/${currentBin} DESTINATION /usr/local/bin OPTIONAL COMPONENT core)
+    endif()
+    if (EXISTS ${CMAKE_CURRENT_BINARY_DIR}/src/stable/tools/${currentBin}/${currentBin})
+        INSTALL (PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/src/stable/tools/${currentBin}/${currentBin} DESTINATION /usr/local/bin OPTIONAL COMPONENT core)
+    endif()
+ENDFOREACH(currentBin)
+
+
 
 # Install interfaces headers
 INSTALL(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/src/stable/interfaces/cpp/jderobot/
@@ -197,11 +219,19 @@ FILE(GLOB SLICE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/stable/interfaces/slice/jd
 INSTALL (FILES ${SLICE_FILES} DESTINATION /usr/local/include/jderobot/slice COMPONENT core)
 
 # Install CONF
-FILE(GLOB_RECURSE CONF_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/stable/components/*.cfg)
+FILE(GLOB_RECURSE CONF_COMPONENT_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/stable/components/*.cfg)
+FILE(GLOB_RECURSE CONF_DRIVER_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/stable/drivers/*.cfg)
+FILE(GLOB_RECURSE CONF_TOOL_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/stable/tools/*.cfg)
+
+SET(CONF_FILES ${CONF_COMPONENT_FILES} ${CONF_DRIVER_FILES} ${CONF_TOOL_FILES})
 INSTALL (FILES ${CONF_FILES} DESTINATION /usr/local/share/jderobot/conf COMPONENT core)
 
 # Install Glade
-FILE(GLOB_RECURSE GLADE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/stable/components/*.glade)
+FILE(GLOB_RECURSE GLADE_COMPONENT_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/stable/components/*.glade)
+FILE(GLOB_RECURSE GLADE_DRIVER_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/stable/drivers/*.glade)
+FILE(GLOB_RECURSE GLADE_TOOL_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/stable/tools/*.glade)
+
+SET(GLADE_FILES ${GLADE_COMPONENT_FILES} ${GLADE_DRIVER_FILES} ${GLADE_TOOL_FILES})
 INSTALL (FILES ${GLADE_FILES} DESTINATION /usr/local/share/jderobot/glade COMPONENT core)
 
 # Install Deps cmake's tree


### PR DESCRIPTION
This should fix the issue #463 by adding in a explicit form the new paths to be taken into account. This fix could be revised a posteriori to make simpler the manipulation of these paths( i.e. : path variable with loop, path discovering...).