### PR TITLE
[Issue #465] Adds blank spaces on package extended description.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,10 +297,10 @@ SET (CPACK_PACKAGE_DESCRIPTION_SUMMARY
 "Software development suite for robotics and computer vision applications.")
 SET (CPACK_PACKAGE_DESCRIPTION
 "JdeRobot is a software development suite for robotics and computer vision applications. 
-The applications are made up of a collection of concurrent processes (named components) that
-interoperate among them. They exchange messages using ICE communication middleware. The components may 
-run in a distributed network of computers and may be written in several languages (C++, Python, JavaScript...). 
-JdeRobot includes a collection of drivers and tools.
+ The applications are made up of a collection of concurrent processes (named components) that
+ interoperate among them. They exchange messages using ICE communication middleware. The components may 
+ run in a distributed network of computers and may be written in several languages (C++, Python, JavaScript...). 
+ JdeRobot includes a collection of drivers and tools.
  Get source from https://github.com/RoboticsURJC/JdeRobot
  Package created with revision ${GIT_HEAD}")
 


### PR DESCRIPTION
Fixes issue #465.

According to Section "5.6.13 Description" of Debian Policy Manual, this commit reinserts the blank spaces of each line in the extended part of the description.
