### PR TITLE
[Issue #468] Quick-fix for x32 openni related components.

### DIFF
--- a/Deps/openni/CMakeLists.txt
+++ b/Deps/openni/CMakeLists.txt
@@ -3,6 +3,15 @@ FIND_PATH( openni_INCLUDE_DIR NAMES XnOpenNI.h  PATHS ENV C++LIB ENV PATH PATH_S
 
 IF( openni_INCLUDE_DIR )
     FIND_LIBRARY( openni_LIBRARIES NAMES OpenNI PATHS ENV C++LIB ENV PATH PATH_SUFFIXES lib lib64)
+   
+    # Quick solution for XnPlatform bug in x32 systems
+    INCLUDE(CheckCXXSymbolExists) 
+    CHECK_CXX_SYMBOL_EXISTS("__i386__" "" __i386)
+    IF(__i386)
+        add_definitions(-Di386)
+        MESSAGE(WARNING "Defining 'i386' preprocessor macro due possible XnPlatform.h bug")
+    ENDIF(__i386)
+    
     IF( openni_LIBRARIES)
 		MESSAGE ("-- OpenNi found at ${openni_LIBRARIES}")
 		include_directories(${openni_INCLUDE_DIR})


### PR DESCRIPTION
This fix sets the preprocessor macro `i386` when the macro `__i386__` is detected, making XiPlatform.h work as intended for x32 linux platforms.

Also outputs a CMake warning as this _fix_ could affect to an hypotetical code using that macro.