### PR TITLE
[Issue #467] Add dpkg package name discovery for boost and pcl.

### DIFF
--- a/Deps/boost/CMakeLists.txt
+++ b/Deps/boost/CMakeLists.txt
@@ -2,6 +2,39 @@ include(FindPkgConfig)
 find_package(Boost COMPONENTS system filesystem REQUIRED)
 INCLUDE_DIRECTORIES( ${Boost_INCLUDE_DIR} )
 
+# Find related packages for this system
+if(Boost_FOUND)
+  # Only is DPKG is found
+  find_program(_DPKG_CMD dpkg)
+  find_program(_READLINK_CMD readlink)
+
+  if(_DPKG_CMD AND _READLINK_CMD)
+
+    foreach(component ${_Boost_COMPONENTS_SEARCHED})
+        string(TOUPPER ${component} COMPONENT)
+
+        if(Boost_${COMPONENT}_FOUND)
+
+            if(Boost_${COMPONENT}_LIBRARY)
+                list(GET Boost_${COMPONENT}_LIBRARY 0 _LIB)
+                execute_process(COMMAND readlink -f ${_LIB} OUTPUT_VARIABLE _LIB OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
+                execute_process(COMMAND dpkg -S ${_LIB} OUTPUT_VARIABLE _PKG)
+                string(REGEX REPLACE "^([^:]+):.*" \\1 _PKG ${_PKG})
+        
+                list(APPEND DEPS ${_PKG})
+            endif(Boost_${COMPONENT}_LIBRARY)
+
+          endif(Boost_${COMPONENT}_FOUND)
+
+    endforeach(component ${Boost_FIND_COMPONENTS})
+  else()
+      message(WARNING "Package dependencies can't be determined safely in this system.")
+      message(WARNING "Build will not be affected, but generated packages with CPack should be checked")
+
+  endif(_DPKG_CMD AND _READLINK_CMD)
+
+endif(Boost_FOUND)
+
 # ubuntu
 
 list(APPEND DEPS libboost-system1.54.0 libboost-filesystem1.54.0)

--- a/Deps/pcl/CMakeLists.txt
+++ b/Deps/pcl/CMakeLists.txt
@@ -6,7 +6,36 @@ INCLUDE_DIRECTORIES( ${PCL_INCLUDE_DIRS})
 if (PCL_INCLUDE_DIRS)
     add_definitions(${PCL_DEFINITIONS})
     set(with_pcl TRUE)
-    list(APPEND DEPS libpcl-visualization-1.7 libpcl-surface-1.7 libpcl-registration-1.7 libpcl-segmentation-1.7 libpcl-filters-1.7 libpcl-sample-consensus-1.7 libpcl-io-1.7 libpcl-octree-1.7 libpcl-features-1.7 libpcl-kdtree-1.7 libpcl-common-1.7)
+
+    # Only is DPKG is found
+    find_program(_DPKG_CMD dpkg)
+    find_program(_READLINK_CMD readlink)
+
+    if(_DPKG_CMD AND _READLINK_CMD)
+
+        foreach(component ${PCL_TO_FIND_COMPONENTS})
+            string(TOUPPER ${component} COMPONENT)
+
+            if(PCL_${COMPONENT}_FOUND)
+
+                if(PCL_${COMPONENT}_LIBRARY)
+                    list(GET PCL_${COMPONENT}_LIBRARY 0 _LIB)
+                    execute_process(COMMAND readlink -f ${_LIB} OUTPUT_VARIABLE _LIB OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
+                    execute_process(COMMAND dpkg -S ${_LIB} OUTPUT_VARIABLE _PKG)
+                    string(REGEX REPLACE "^([^:]+):.*" \\1 _PKG ${_PKG})
+
+                    list(APPEND DEPS ${_PKG})
+                endif(PCL_${COMPONENT}_LIBRARY)
+
+            endif(PCL_${COMPONENT}_FOUND)
+
+        endforeach(component ${PCL_TO_FIND_COMPONENTS})
+    else()
+        message(WARNING "Package dependencies can't be determined safely in this system.")
+        message(WARNING "Build will not be affected, but generated packages with CPack should be checked")
+
+    endif(_DPKG_CMD AND _READLINK_CMD)
+
     list(APPEND DEPS_DEV libpcl-all)
     FIND_PATH( pcl_openni NAMES pcl/io/openni_grabber.h HINTS ${PCL_INCLUDE_DIRS})
 endif()


### PR DESCRIPTION
Fixes issue #467 for boost and pcl libraries. 

Important notes:
* This fix works for a dpkg-based system and for libraries installed from a package, as it uses this command to find which package installed which file.
* This fix uses undocumented CMake variables inside `FindBoost.cmake`and `FindPCL.cmake` in order to make easier and quick the search task. Any upstream changes to these files could break this fix.
* This fix checks for the existence of the commands needed before performing the search; for systems without these commands, a CMake warning is issued telling the user to check any package made via CPack and that the normal build will not be affected.