### PR TITLE
Gazebo models with plugin absolute paths: yellow and white Taxi

### DIFF
--- a/src/stable/drivers/gazeboserver/models/whiteTaxi/model.sdf
+++ b/src/stable/drivers/gazeboserver/models/whiteTaxi/model.sdf
@@ -344,7 +344,7 @@
           <xyz>1 0 0</xyz>
         </axis>
       </joint>
-      <plugin name="carMotors" filename="/usr/local/share/jderobot/gazebo/plugins/car/libcarMotors.so">
+      <plugin name="carMotors" filename="libcarMotors.so">
         <front_right_joint>front_right_wheel_hinge</front_right_joint>
         <front_left_joint>front_left_wheel_hinge</front_left_joint>
         <front_right_steering_joint>front_right_steering_wheel</front_right_steering_joint>

--- a/src/stable/drivers/gazeboserver/models/yellowTaxi/model.sdf
+++ b/src/stable/drivers/gazeboserver/models/yellowTaxi/model.sdf
@@ -345,7 +345,7 @@
           <xyz>1 0 0</xyz>
         </axis>
       </joint>
-      <plugin name="carMotors" filename="/usr/local/share/jderobot/gazebo/plugins/car/libcarMotors.so">
+      <plugin name="carMotors" filename="libcarMotors.so">
         <front_right_joint>front_right_wheel_hinge</front_right_joint>
       	<front_left_joint>front_left_wheel_hinge</front_left_joint>
 			  <front_right_steering_joint>front_right_steering_wheel</front_right_steering_joint>


### PR DESCRIPTION
This pull request should fix #493 for the following models:
- yellowTaxi
- whiteTaxi