### PR TITLE
[Issue #467] Fixes package discovery for boost

### DIFF
--- a/Deps/boost/CMakeLists.txt
+++ b/Deps/boost/CMakeLists.txt
@@ -34,7 +34,3 @@ if(Boost_FOUND)
   endif(_DPKG_CMD AND _READLINK_CMD)
 
 endif(Boost_FOUND)
-
-# ubuntu
-
-list(APPEND DEPS libboost-system1.54.0 libboost-filesystem1.54.0)


### PR DESCRIPTION
Some lines regarding the static variable injection weren't removed in the last pull request about this issue (PR #488), making Debian Packages again to have wrong dependency chain.
This pull request should fix this bug.